### PR TITLE
feat: typography in twind

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -38,11 +38,7 @@ const Style: Story<TextProps> = args => {
   `;
   return (
     <div className="w-full h-1/2 flex justify-center bg-white py-4">
-      <Text
-        styles={styles}
-        className="font-bold text-red-800 text-5xl"
-        {...args}
-      >
+      <Text styles={styles} {...args}>
         Override By Styles Props
       </Text>
     </div>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { tw, style, apply } from 'twind/style';
+import { camelize, resolveClasses } from '../../utils/classes/resolveClasses';
 
 type TextTags =
   | 'h1'
@@ -55,7 +56,7 @@ export interface TextClasses {
   rootBodyLg: string;
   rootBodyMd: string;
   rootBodySm: string;
-  rootButton: string;
+  rootButtonLg: string;
 }
 
 const defaultClasses: TextClasses = {
@@ -66,28 +67,7 @@ const defaultClasses: TextClasses = {
   rootBodyLg: 'text-base leading-5',
   rootBodyMd: 'text-sm leading-4',
   rootBodySm: 'text-xs leading-3',
-  rootButton: 'text-lg font-semibold leading-6',
-};
-
-type Rec = { [key: string]: string } | TextClasses;
-const resolveClasses = (user: Rec, def: Rec) => {
-  const hash: any = {};
-  Object.keys(def).map(k => {
-    if (user.hasOwnProperty(k)) {
-      hash[k] = `${(def as any)[k]} ${(user as any)[k]}`;
-    } else {
-      hash[k] = (def as any)[k];
-    }
-  });
-  return hash;
-};
-
-const camelize = (str: string): string => {
-  return str
-    .replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
-      return index === 0 ? word.toLowerCase() : word.toUpperCase();
-    })
-    .replace(/\s+/g, '');
+  rootButtonLg: 'text-lg font-semibold leading-6',
 };
 
 export const Text: React.FC<PropsWithChildren<TextProps>> = ({
@@ -103,7 +83,6 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
     classes || {},
     defaultClasses,
   );
-  const rootClass = `hmsui-typography`;
   const TagName = tag || 'p';
   const typography = style({
     // base
@@ -142,14 +121,15 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
       {
         variant: 'button',
         size: 'sm',
-        use: `${finalClasses.rootButton}`,
+        use: `${finalClasses.rootButtonLg}`,
       },
     ],
   });
   const twClasses = typography({ size, variant });
   const propClass = 'hmsui ' + camelize(`root ${variant} ${size}`);
+  const className = tw(propClass, twClasses);
   return (
-    <TagName className={tw(propClass, twClasses)} {...props}>
+    <TagName className={className} {...props}>
       {children}
     </TagName>
   );

--- a/src/utils/classes/resolveClasses.tsx
+++ b/src/utils/classes/resolveClasses.tsx
@@ -1,0 +1,20 @@
+
+export const resolveClasses = (user: any, def: any) => {
+  const hash: any = {};
+  Object.keys(def).map(k => {
+    if (user.hasOwnProperty(k)) {
+      hash[k] = `${(def as any)[k]} ${(user as any)[k]}`;
+    } else {
+      hash[k] = (def as any)[k];
+    }
+  });
+  return hash;
+};
+
+export const camelize = (str: string): string => {
+  return str
+    .replace(/(?:^\w|[A-Z]|\b\w)/g, function(word, index) {
+      return index === 0 ? word.toLowerCase() : word.toUpperCase();
+    })
+    .replace(/\s+/g, '');
+};


### PR DESCRIPTION
Introduced and Implemented Typography(Text) Component in Twind

There's 4 ways User can Overriden Styles

1. `className` prop would always replace the default styles
2. Custom `.css` file (Might need !important in some case)
3. Twind's `css` func and components `style` prop
4. Inline Styles  via `style` prop would always take precedence 
