### PR TITLE
feat: add icon button to TwButton

### DIFF
--- a/src/components/TwButton/Button.stories.tsx
+++ b/src/components/TwButton/Button.stories.tsx
@@ -65,6 +65,18 @@ const Classes: Story<ButtonProps> = args => {
   );
 };
 
+const IconOnly: Story<ButtonProps> = args => {
+  return (
+    <div className="w-full h-1/2 flex justify-center bg-white py-4">
+      <HMSThemeProvider config={{}} appBuilder={{ theme: 'dark' }}>
+        <Button iconOnly iconSize="sm" {...args}>
+          <MicOffIcon />
+        </Button>
+      </HMSThemeProvider>
+    </div>
+  );
+};
+
 export const Default = Basic.bind({});
 Basic.args = {};
 
@@ -75,4 +87,7 @@ export const IconRightButton = IconRight.bind({});
 Basic.args = {};
 
 export const ButtonClasses = Classes.bind({});
+Basic.args = {};
+
+export const IconOnlyButton = IconOnly.bind({});
 Basic.args = {};

--- a/src/components/TwButton/Button.tsx
+++ b/src/components/TwButton/Button.tsx
@@ -53,6 +53,14 @@ interface StyledButtonProps {
    */
   size?: 'sm' | 'md' | 'lg';
   /**
+   * Only Case
+   */
+  iconOnly?: boolean;
+  /**
+   * Icon Size
+   */
+  iconSize?: 'sm' | 'md' | 'lg';
+  /**
    * Shape
    */
   shape?: 'circle' | 'rectangle';
@@ -106,6 +114,9 @@ export interface ButtonClasses {
   rootSizeSm: string;
   rootSizeMd: string;
   rootSizeLg: string;
+  rootIconSizeSm: string;
+  rootIconSizeMd: string;
+  rootIconSizeLg: string;
 }
 
 const defaultClasses: ButtonClasses = {
@@ -122,6 +133,9 @@ const defaultClasses: ButtonClasses = {
   rootSizeSm: 'px-2.5 py-1.5',
   rootSizeMd: 'px-4 py-2',
   rootSizeLg: 'px-6 py-3',
+  rootIconSizeSm: 'p-2',
+  rootIconSizeMd: 'p-3',
+  rootIconSizeLg: 'p-4',
 };
 
 export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
@@ -133,6 +147,8 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
   icon,
   classes,
   size = 'md',
+  iconSize = 'md',
+  iconOnly,
   iconRight,
   children,
   ...props
@@ -165,17 +181,32 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
         md: `${finalClasses.rootSizeMd}`,
         lg: `${finalClasses.rootSizeLg}`,
       },
+      iconSize: {
+        sm: `${finalClasses.rootIconSizeSm}`,
+        md: `${finalClasses.rootIconSizeMd}`,
+        lg: `${finalClasses.rootIconSizeLg}`,
+      },
     },
   });
-  const twClasses = tw(
-    button({
-      variant: variant,
-      disabled: disabled,
-      focus: focus,
-      shape: shape,
-      size: size,
-    }),
-  );
+  const twClasses = !iconOnly
+    ? tw(
+        button({
+          variant: variant,
+          disabled: disabled,
+          focus: focus,
+          shape: shape,
+          size: size,
+        }),
+      )
+    : tw(
+        button({
+          variant: variant,
+          disabled: disabled,
+          focus: focus,
+          shape: shape,
+          iconSize: iconSize,
+        }),
+      );
   // TODO: chaining descriptive classNames so that user knows which to override
   const propClass = 'hmsui-button';
   const className = tw(propClass, twClasses);


### PR DESCRIPTION
Integrated Directly into `<TwButton />` Component

This is not a `variant`,  to use this we have to pass `iconOnly` as boolean and set `iconSize` if we want

<img width="1211" alt="Screenshot 2021-05-11 at 11 48 10 PM" src="https://user-images.githubusercontent.com/61158210/117865899-1587a280-b2b4-11eb-8109-b669b53204e3.png">

```jsx
<Button iconOnly iconSize="sm" {...args}>
<MicOffIcon />
</Button>

<Button iconOnly {...args}>
<MicOffIcon />
</Button>

<Button iconOnly iconSize="lg" {...args}>
<MicOffIcon />
</Button>

<Button variant="danger" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button variant="emphasized" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button variant="no-fill" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button variant="danger" shape="circle" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button variant="emphasized" shape="circle" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button variant="no-fill" shape="circle" iconOnly {...args}>
<MicOffIcon />
</Button>

<Button
classes={{ rootCircle: 'rounded-none' }}
variant="no-fill"
shape="circle"
iconOnly
{...args}
>
<MicOffIcon />
</Button>
```