### PR TITLE
feat: avatar bg-colors

### DIFF
--- a/src/components/TwAvatar/Avatar.tsx
+++ b/src/components/TwAvatar/Avatar.tsx
@@ -32,7 +32,7 @@ interface AvatarPropsWithoutNativeAttrs {
    * Extra class names
    */
   classes?: AvatarClasses;
-  avatarType?: 'initial' | 'pebble' | 'icon' | 'image';
+  avatarType?: 'initial' | 'pebble' | 'icon' | 'image' | 'gradient';
 }
 
 export type AvatarProps = AvatarPropsWithoutNativeAttrs &
@@ -83,6 +83,29 @@ const colorsArr = [
   '#455A64',
 ];
 
+const gradArr = [
+  ['#FAA49E', '#FF1908'],
+  ['#92A1F1', '#394FC8'],
+  ['#00B33D', ' #004106'],
+  ['#FFB12D ', '#AB6B00 '],
+  ['#B29287 ', '#8F5039 '],
+  ['#FF548E ', '#BD0E4A '],
+  ['#2F80FF ', '#054CBB '],
+  ['#98E43F ', '#559906 '],
+  ['#DD7000 ', '#663400 '],
+  ['#966A60 ', '#4C1D12 '],
+  ['#E449FF ', '#85059B '],
+  ['#AEE9F0 ', '#09C3DA '],
+  ['#E9F35B ', '#939D00 '],
+  ['#FFD179 ', '#FF4004 '],
+  ['#B6B6B6 ', '#5F5C5C '],
+  ['#8750EA ', '#4511A0 '],
+  ['#00E1CC ', '#008376 '],
+  ['#F1D4A8 ', '#F1A40E '],
+  ['#EC3F0A ', '#5E1600 '],
+  ['#667D88 ', '#22566E '],
+];
+
 export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
   size = 'sm',
   label,
@@ -122,14 +145,30 @@ export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
   } else if (size === 'xl') {
     classList.push(`${styler('rootSizeXl')}`);
   }
-  const pebble = ((label?.codePointAt(0) || 0) % 6) + 1;
+
+  const indexFactor = avatarType === 'pebble' ? 6 : 20;
+  const colorIndex = useMemo(
+    () => ((label?.codePointAt(0) || 0) % indexFactor) + 1,
+    [],
+  );
   const map = {
     initial: (
       <div
         {...props}
         className={classList.join(' ')}
         style={{
-          backgroundColor: `${colorsArr[pebble]}`,
+          backgroundColor: `${colorsArr[colorIndex]}`,
+        }}
+      >
+        {getInitialsFromName(label)}
+      </div>
+    ),
+    gradient: (
+      <div
+        {...props}
+        className={classList.join(' ')}
+        style={{
+          background: `linear-gradient(180deg, ${gradArr[colorIndex][0]} 0%, ${gradArr[colorIndex][1]} 100%)`,
         }}
       >
         {getInitialsFromName(label)}
@@ -139,7 +178,7 @@ export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
       <img
         {...props}
         className={classList.join(' ')}
-        src={`https://bc-public-static-assets.s3.ap-south-1.amazonaws.com/dashboard/images/Pebble%20People/${pebble}.svg`}
+        src={`https://bc-public-static-assets.s3.ap-south-1.amazonaws.com/dashboard/images/Pebble%20People/${colorIndex}.svg`}
       />
     ),
     icon: (


### PR DESCRIPTION
Added Avatar BgColor according to the Figma Design

Uses only 6 variants for now.