### PR TITLE
fix: Correctly query carousel width and height.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.45",
+  "version": "0.3.46",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/VideoList/VideoList.tsx
+++ b/src/components/VideoList/VideoList.tsx
@@ -253,9 +253,10 @@ export const VideoList = ({
 
   return (
     <div className={`${styler('root')}`}>
-      {chunkedTracksWithPeer && chunkedTracksWithPeer.length > 0 && (
-        <Carousel ref={ref}>
-          {chunkedTracksWithPeer.map((tracksPeersOnOnePage, page) => {
+      <Carousel ref={ref}>
+        {chunkedTracksWithPeer &&
+          chunkedTracksWithPeer.length > 0 &&
+          chunkedTracksWithPeer.map((tracksPeersOnOnePage, page) => {
             return (
               <div className={`${styler('sliderInner')}`} key={page}>
                 <div
@@ -301,8 +302,7 @@ export const VideoList = ({
               </div>
             );
           })}
-        </Carousel>
-      )}
+      </Carousel>
     </div>
   );
 };


### PR DESCRIPTION
Carousel width and height should be queried only after the carousel is rendered. 