### PR TITLE
fix: control bar layout on mobile

### DIFF
--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -42,9 +42,9 @@ export interface ControlBarProps {
 // Note: Column Gap is not supported in safari
 const defaultClasses: ControlBarClasses = {
   root:
-    'flex bg-white dark:bg-black h-full items-center p-3 mr-2 ml-2 justify-center md:justify-between ',
-  leftRoot: 'flex justify-center justify-between w-10 md:w-44 z-10',
-  centerRoot: 'flex md:flex-1 mr-4 md:mr-0 justify-center md:-translate-x-5',
+    'flex bg-white dark:bg-black h-full items-center p-1 md:p-3 mr-0 ml-0 md:mr-2 md:ml-2 justify-between ',
+  leftRoot: 'flex justify-center justify-between z-10',
+  centerRoot: 'flex justify-center',
   rightRoot: '',
 };
 


### PR DESCRIPTION
Before:

<img width="670" alt="Screenshot 2021-07-11 at 12 47 19 PM" src="https://user-images.githubusercontent.com/61158210/125186156-49485f80-e246-11eb-9361-d4bfaea26a51.png">

After:

<img width="688" alt="Screenshot 2021-07-11 at 12 46 22 PM" src="https://user-images.githubusercontent.com/61158210/125186128-274edd00-e246-11eb-8e7b-809985bf138f.png">

