### PR TITLE
chore: Bump versions, add avatar, label for degraded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.67",
+  "version": "0.2.68",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": ">=16",
-    "@100mslive/hms-video": "^0.0.92"
+    "@100mslive/hms-video": "^0.0.95"
   },
   "husky": {
     "hooks": {
@@ -52,7 +52,7 @@
     }
   ],
   "devDependencies": {
-    "@100mslive/hms-video": "^0.0.92",
+    "@100mslive/hms-video": "^0.0.95",
     "@babel/core": "^7.13.14",
     "@rollup/plugin-image": "^2.0.6",
     "@size-limit/preset-small-lib": "^4.10.2",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.1.55",
+    "@100mslive/hms-video-store": "^0.1.56",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -195,7 +195,7 @@ export const VideoTile = ({
   }
 
   if (!showScreen && (isVideoMuted === undefined || isVideoMuted === null)) {
-    isVideoMuted = storeIsVideoMuted;
+    isVideoMuted = storeIsVideoMuted || Boolean(hmsVideoTrack?.degraded);
   }
 
   const label = getVideoTileLabel(
@@ -203,6 +203,7 @@ export const VideoTile = ({
     peer.isLocal,
     hmsVideoTrack?.source,
     storeIsLocallyMuted,
+    hmsVideoTrack?.degraded,
   );
 
   try {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,7 +13,8 @@ const getVideoTileLabel = (
   peerName: string,
   isLocal: boolean,
   videoSource: HMSTrackSource = 'regular',
-  isLocallyMuted?: boolean | undefined,
+  isLocallyMuted?: boolean,
+  degraded?: boolean,
 ) => {
   // Map [isLocal, videoSource] to the label to be displayed.
   const labelMap = new Map<string, string>([
@@ -25,6 +26,7 @@ const getVideoTileLabel = (
   ]);
 
   let label = labelMap.get([isLocal, videoSource].toString());
+  label = `${label}${degraded ? '(Degraded)' : ''}`;
   if (isLocallyMuted === undefined || isLocallyMuted === null) {
     return label;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.1.55":
-  version "0.1.55"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.55.tgz#9b6b85fca125e2da7f0736f05100181c83f6ca79"
-  integrity sha512-28jsvlKKiXgKnYFDHmpheSTfppCiX7f0AkYcgathGrv8yZd3GLT5rgC/Xk6pTdoCrTW/JFdq2wPwZFeIdGUSVQ==
+"@100mslive/hms-video-store@^0.1.56":
+  version "0.1.56"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.56.tgz#77d23dfc6da284238bf2343f79c203151a34f84c"
+  integrity sha512-n8LaKhQDBJ0XSjHW+QJx4LiggBtQTOupb+R7ozc96aDZrKwym5wy9pW7k49V8pDPXopaG5BV6/IfPOxEXZl8ew==
   dependencies:
     immer "^9.0.2"
     reselect "^4.0.0"
     zustand "3.5.4"
 
-"@100mslive/hms-video@^0.0.92":
-  version "0.0.92"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.92.tgz#dc395bbdce2549c5bb2f5e3b7d7cd060b2649565"
-  integrity sha512-i84vhtPxjKUX5L2OsdBt1hpIh/PTgPYbtzQ9PtiwyC1U3jw1EKBr2f94ovAxnVNPn+gOQ62U2xdHeNZuHPDptw==
+"@100mslive/hms-video@^0.0.95":
+  version "0.0.95"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.95.tgz#f5842d7adf06c3c531dc69b702a95f5885e820a4"
+  integrity sha512-AXcz4cjpiPd2w7xerT4QODmughTEzuF0VVJ7KP4RRvCSjY6DHA8G6FjD7hugIKo59fuOQMicb4UWiJ173Ond4w==
   dependencies:
     events "^3.3.0"
     sdp-transform "^2.14.1"


### PR DESCRIPTION
## Details
Show avatar and indicate the label that the video tile's track has been degraded

### Current Behaviour
No visual indication of track degradation


### New Behaviour
Avatar is shown and label would be appended with '(Degraded)'.




### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
