### PR TITLE
fix: show simulcast options conditionally

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.68",
+  "version": "0.2.69",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": ">=16",
-    "@100mslive/hms-video": "^0.0.95"
+    "@100mslive/hms-video": "^0.0.98"
   },
   "husky": {
     "hooks": {
@@ -52,7 +52,7 @@
     }
   ],
   "devDependencies": {
-    "@100mslive/hms-video": "^0.0.95",
+    "@100mslive/hms-video": "^0.0.98",
     "@babel/core": "^7.13.14",
     "@rollup/plugin-image": "^2.0.6",
     "@size-limit/preset-small-lib": "^4.10.2",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.1.56",
+    "@100mslive/hms-video-store": "^0.1.57",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": ">=16",
-    "@100mslive/hms-video": "^0.0.98"
+    "@100mslive/hms-video": "^0.0.99"
   },
   "husky": {
     "hooks": {
@@ -52,7 +52,7 @@
     }
   ],
   "devDependencies": {
-    "@100mslive/hms-video": "^0.0.98",
+    "@100mslive/hms-video": "^0.0.99",
     "@babel/core": "^7.13.14",
     "@rollup/plugin-image": "^2.0.6",
     "@size-limit/preset-small-lib": "^4.10.2",

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -87,7 +87,9 @@ export const ContextMenuItem = ({
       style={{ minHeight: 40 }}
     >
       {icon && <span className={styler('menuIcon')}>{icon}</span>}
-      <span className={styler('menuTitle')}>{label}</span>
+      <span className={styler('menuTitle')} title={label}>
+        {label}
+      </span>
       {children && <div className={styler('menuItemChildren')}>{children}</div>}
     </div>
   );
@@ -115,6 +117,11 @@ export const ContextMenu = ({
   useEffect(() => {
     setOpen(menuOpen);
   }, [menuOpen]);
+
+  // Don't render context menu when no children are present
+  if (!children || (Array.isArray(children) && children.length === 0)) {
+    return null;
+  }
 
   return (
     <div className={styler('root')}>

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -206,6 +206,8 @@ export const VideoTile = ({
     hmsVideoTrack?.degraded,
   );
 
+  const layerDefinitions = hmsVideoTrack?.layerDefinitions || [];
+
   try {
     if (aspectRatio === undefined) {
       aspectRatio = appBuilder.videoTileAspectRatio;
@@ -268,21 +270,19 @@ export const VideoTile = ({
           ) : (
             <Fragment />
           )}
-          <ContextMenuItem
-            label="Low"
-            active={simulcastLayer === HMSSimulcastLayer.LOW}
-            onClick={() => updateSimulcastLayer(HMSSimulcastLayer.LOW)}
-          />
-          <ContextMenuItem
-            label="Medium"
-            active={simulcastLayer === HMSSimulcastLayer.MEDIUM}
-            onClick={() => updateSimulcastLayer(HMSSimulcastLayer.MEDIUM)}
-          />
-          <ContextMenuItem
-            label="High"
-            active={simulcastLayer === HMSSimulcastLayer.HIGH}
-            onClick={() => updateSimulcastLayer(HMSSimulcastLayer.HIGH)}
-          />
+          <Fragment>
+            {layerDefinitions.map(({ layer, resolution }) => {
+              return (
+                <ContextMenuItem
+                  label={`${layer.toUpperCase()} (${resolution.width}x${
+                    resolution.height
+                  })`}
+                  active={simulcastLayer === layer}
+                  onClick={() => updateSimulcastLayer(layer)}
+                />
+              );
+            })}
+          </Fragment>
         </ContextMenu>
       )}
       {((impliedAspectRatio.width && impliedAspectRatio.height) ||

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,7 +27,10 @@ const getVideoTileLabel = (
 
   let label = labelMap.get([isLocal, videoSource].toString());
   label = `${label}${degraded ? '(Degraded)' : ''}`;
-  if (isLocallyMuted === undefined || isLocallyMuted === null) {
+  if (
+    (isLocallyMuted === undefined || isLocallyMuted === null) &&
+    videoSource === 'regular'
+  ) {
     return label;
   }
   return `${label}${isLocallyMuted ? ' (Muted for you)' : ''}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,10 +11,10 @@
     reselect "^4.0.0"
     zustand "3.5.4"
 
-"@100mslive/hms-video@^0.0.98":
-  version "0.0.98"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.98.tgz#999867031f73dbc86b2e327ec6f68d778e47e1d2"
-  integrity sha512-ngZh9K8wSvjbNN1VMcFtOAHtSAg1vXyGW3QjyC9H1Umpe41juO0HnmOVmvWzGz7xrBF6lzKGq/BGtWNqFfDZGg==
+"@100mslive/hms-video@^0.0.99":
+  version "0.0.99"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.99.tgz#9e27bd9529db67725c6ea5bdac32efc2a5ba3f5d"
+  integrity sha512-0mby/dfXzwtVYKESpmhFxE5AZ88MbWA1X2VX1tVEiB3Nx8Vt6k4qGEISXJTgS69GY821E8xRDy8kn9mXH/7f6w==
   dependencies:
     events "^3.3.0"
     sdp-transform "^2.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.1.56":
-  version "0.1.56"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.56.tgz#77d23dfc6da284238bf2343f79c203151a34f84c"
-  integrity sha512-n8LaKhQDBJ0XSjHW+QJx4LiggBtQTOupb+R7ozc96aDZrKwym5wy9pW7k49V8pDPXopaG5BV6/IfPOxEXZl8ew==
+"@100mslive/hms-video-store@^0.1.57":
+  version "0.1.57"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.57.tgz#53b30eddbdc8e739ad66e6e844dffed6c09003cb"
+  integrity sha512-pmE9ZFFxBZgIu61SvIGVNLrkaM4lXvtjGSdo+oy7ky/o1QYYC40mbllS0g69w4RGIPxYVATSO5DlPH/fjxy89Q==
   dependencies:
     immer "^9.0.2"
     reselect "^4.0.0"
     zustand "3.5.4"
 
-"@100mslive/hms-video@^0.0.95":
-  version "0.0.95"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.95.tgz#f5842d7adf06c3c531dc69b702a95f5885e820a4"
-  integrity sha512-AXcz4cjpiPd2w7xerT4QODmughTEzuF0VVJ7KP4RRvCSjY6DHA8G6FjD7hugIKo59fuOQMicb4UWiJ173Ond4w==
+"@100mslive/hms-video@^0.0.98":
+  version "0.0.98"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.98.tgz#999867031f73dbc86b2e327ec6f68d778e47e1d2"
+  integrity sha512-ngZh9K8wSvjbNN1VMcFtOAHtSAg1vXyGW3QjyC9H1Umpe41juO0HnmOVmvWzGz7xrBF6lzKGq/BGtWNqFfDZGg==
   dependencies:
     events "^3.3.0"
     sdp-transform "^2.14.1"


### PR DESCRIPTION
## Details

### Current Behaviour
- Simulcast options are hardcoded

### New Behaviour
- Pick Simulcast options from the track layer definitions


### Screenshots



### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
