### PR TITLE
fix: show setttings based on role

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.74",
+  "version": "0.2.75",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.75",
+  "version": "0.3.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.1.59",
+    "@100mslive/hms-video-store": "^0.1.60",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/Preview/Controls/PreviewControls.tsx
+++ b/src/components/Preview/Controls/PreviewControls.tsx
@@ -1,13 +1,11 @@
 import React, { useMemo } from 'react';
-import { useHMSTheme } from '../../../hooks/HMSThemeProvider';
-import { hmsUiClassParserGenerator } from '../../../utils/classes';
-import '../index.css';
-import { ButtonDisplayType } from '../../../types';
 import { MicOffIcon, MicOnIcon, CamOnIcon, CamOffIcon } from '../../Icons';
 import { Button } from '../../Button';
 import { Settings, SettingsFormProps } from '../../Settings/Settings';
-import { useHMSStore } from '../../../hooks/HMSRoomProvider';
-import { selectLocalMediaSettings } from '@100mslive/hms-video-store';
+import { useHMSTheme } from '../../../hooks/HMSThemeProvider';
+import { ButtonDisplayType } from '../../../types';
+import { hmsUiClassParserGenerator } from '../../../utils/classes';
+import '../index.css';
 
 interface PreviewControlsClasses {
   root?: string;
@@ -60,9 +58,6 @@ export const PreviewControls = ({
       }),
     [],
   );
-  const { audioInputDeviceId, videoInputDeviceId } = useHMSStore(
-    selectLocalMediaSettings,
-  );
 
   return (
     <div className={`${styler('root')}`}>
@@ -87,9 +82,7 @@ export const PreviewControls = ({
         </Button>
       </div>
       <div className={`${styler('rightControls')}`}>
-        {audioInputDeviceId && videoInputDeviceId && (
-          <Settings onChange={onChange} key={0} previewMode={true} />
-        )}
+        <Settings onChange={onChange} key={0} previewMode={true} />
       </div>
     </div>
   );

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -174,14 +174,18 @@ export const Settings = ({
   const audioOutput = devices['audioOutput'] || [];
   let showVideo = false;
   let showAudio = false;
+  let isSubscribing = false;
   if (role?.publishParams?.allowed) {
     showVideo = role.publishParams.allowed.includes('video');
     showAudio = role.publishParams.allowed.includes('audio');
   }
-  //TODO handle case where selected device is not in list
-  // audioOutput.length > 0 && audioOutput.findIndex(device => device.deviceId===values?.selectedAudioOutput)===-1 && setValues({selectedAudioOutput:videoInput[0].deviceId});
-  // audioInput.length > 0 && audioInput.findIndex(device => device.deviceId===values?.selectedAudioInput)===-1 && setValues({selectedAudioInput:videoInput[0].deviceId});
-  // videoInput.length > 0 && videoInput.findIndex(device => device.deviceId===values?.selectedVideoInput)===-1 && setValues({selectedVideoInput:videoInput[0].deviceId});
+  if (role?.subscribeParams?.subscribeToRoles) {
+    isSubscribing = role.subscribeParams.subscribeToRoles.length > 0;
+  }
+  const showSettings = [showVideo, showAudio, isSubscribing].some(val => !!val);
+  if (!showSettings) {
+    return null;
+  }
 
   return (
     <>
@@ -286,43 +290,49 @@ export const Settings = ({
                   </div>
                 )}
                 {/** Enabled this when the output is handled properly */}
-                <div className={`${styler('formInner')}`}>
-                  <div className={`${styler('selectLabel')}`}>
-                    <Text variant="heading" size="sm">
-                      Audio Output:
-                    </Text>
-                  </div>
-                  <div className={`${styler('selectContainer')}`}>
-                    {audioOutput.length > 0 && (
-                      <select
-                        name="selectedAudioOutput"
-                        className={`${styler('select')}`}
-                        onChange={handleInputChange}
-                        value={values.selectedAudioOutput}
-                      >
-                        {audioOutput.map((device: MediaDeviceInfo) => (
-                          <option
-                            value={device.deviceId}
+                {isSubscribing && (
+                  <>
+                    <div className={`${styler('formInner')}`}>
+                      <div className={`${styler('selectLabel')}`}>
+                        <Text variant="heading" size="sm">
+                          Audio Output:
+                        </Text>
+                      </div>
+                      <div className={`${styler('selectContainer')}`}>
+                        {audioOutput.length > 0 && (
+                          <select
+                            name="selectedAudioOutput"
                             className={`${styler('select')}`}
-                            key={device.deviceId}
+                            onChange={handleInputChange}
+                            value={values.selectedAudioOutput}
                           >
-                            {device.label}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
-                </div>
-                <div className={`${styler('formInner')}`}>
-                  <div className={`${styler('selectLabel')}`}>
-                    <Text variant="heading" size="sm">
-                      Test Audio Level:
-                    </Text>
-                  </div>
-                  <div className={`${styler('testAudioContainer')}`}>
-                    <TestAudio outputDeviceId={values.selectedAudioOutput} />
-                  </div>
-                </div>
+                            {audioOutput.map((device: MediaDeviceInfo) => (
+                              <option
+                                value={device.deviceId}
+                                className={`${styler('select')}`}
+                                key={device.deviceId}
+                              >
+                                {device.label}
+                              </option>
+                            ))}
+                          </select>
+                        )}
+                      </div>
+                    </div>
+                    <div className={`${styler('formInner')}`}>
+                      <div className={`${styler('selectLabel')}`}>
+                        <Text variant="heading" size="sm">
+                          Test Audio Level:
+                        </Text>
+                      </div>
+                      <div className={`${styler('testAudioContainer')}`}>
+                        <TestAudio
+                          outputDeviceId={values.selectedAudioOutput}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
               </>
             ) : (
               <div className={styler('errorContainer')}>
@@ -331,7 +341,7 @@ export const Settings = ({
               </div>
             )}
             {/** Hide participants view for mobile */}
-            {!isMobileDevice() && (
+            {!isMobileDevice() && isSubscribing && (
               <>
                 <div className={styler('divider')}></div>
                 <div className={styler('sliderContainer')}>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import {
   selectLocalMediaSettings,
   selectDevices,
+  selectLocalPeerRole,
 } from '@100mslive/hms-video-store';
 import { Button as TwButton } from '../Button';
 import { Text } from '../Text';
@@ -112,6 +113,7 @@ export const Settings = ({
 
   const storeInitialValues = useHMSStore(selectLocalMediaSettings);
   const devices = useHMSStore(selectDevices);
+  const role = useHMSStore(selectLocalPeerRole);
 
   const [open, setOpen] = useState(false);
   const [error, setError] = useState('');
@@ -170,6 +172,12 @@ export const Settings = ({
   const videoInput = devices['videoInput'] || [];
   const audioInput = devices['audioInput'] || [];
   const audioOutput = devices['audioOutput'] || [];
+  let showVideo = false;
+  let showAudio = false;
+  if (role?.publishParams?.allowed) {
+    showVideo = role.publishParams.allowed.includes('video');
+    showAudio = role.publishParams.allowed.includes('audio');
+  }
   //TODO handle case where selected device is not in list
   // audioOutput.length > 0 && audioOutput.findIndex(device => device.deviceId===values?.selectedAudioOutput)===-1 && setValues({selectedAudioOutput:videoInput[0].deviceId});
   // audioInput.length > 0 && audioInput.findIndex(device => device.deviceId===values?.selectedAudioInput)===-1 && setValues({selectedAudioInput:videoInput[0].deviceId});
@@ -218,61 +226,65 @@ export const Settings = ({
           <div className={`${styler('formContainer')}`}>
             {error === '' ? (
               <>
-                <div className={`${styler('formInner')}`}>
-                  <div className={`${styler('selectLabel')}`}>
-                    <Text variant="heading" size="sm">
-                      Camera:
-                    </Text>
+                {showVideo && (
+                  <div className={`${styler('formInner')}`}>
+                    <div className={`${styler('selectLabel')}`}>
+                      <Text variant="heading" size="sm">
+                        Camera:
+                      </Text>
+                    </div>
+                    <div className={`${styler('selectContainer')}`}>
+                      {videoInput.length > 0 && (
+                        <select
+                          name="selectedVideoInput"
+                          className={`${styler('select')}`}
+                          onChange={handleInputChange}
+                          value={values.selectedVideoInput}
+                        >
+                          {videoInput.map((device: InputDeviceInfo) => (
+                            <option
+                              value={device.deviceId}
+                              className={`${styler('selectInner')}`}
+                              key={device.deviceId}
+                            >
+                              {device.label} {device.deviceId}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
                   </div>
-                  <div className={`${styler('selectContainer')}`}>
-                    {videoInput.length > 0 && (
-                      <select
-                        name="selectedVideoInput"
-                        className={`${styler('select')}`}
-                        onChange={handleInputChange}
-                        value={values.selectedVideoInput}
-                      >
-                        {videoInput.map((device: InputDeviceInfo) => (
-                          <option
-                            value={device.deviceId}
-                            className={`${styler('selectInner')}`}
-                            key={device.deviceId}
-                          >
-                            {device.label} {device.deviceId}
-                          </option>
-                        ))}
-                      </select>
-                    )}
-                  </div>
-                </div>
-                <div className={`${styler('formInner')}`}>
-                  <div className={`${styler('selectLabel')}`}>
-                    <Text variant="heading" size="sm">
-                      Microphone:
-                    </Text>
-                  </div>
+                )}
+                {showAudio && (
+                  <div className={`${styler('formInner')}`}>
+                    <div className={`${styler('selectLabel')}`}>
+                      <Text variant="heading" size="sm">
+                        Microphone:
+                      </Text>
+                    </div>
 
-                  <div className={`${styler('selectContainer')}`}>
-                    {audioInput.length > 0 && (
-                      <select
-                        name="selectedAudioInput"
-                        className={`${styler('select')}`}
-                        onChange={handleInputChange}
-                        value={values.selectedAudioInput}
-                      >
-                        {audioInput.map((device: InputDeviceInfo) => (
-                          <option
-                            value={device.deviceId}
-                            className={`${styler('selectInner')}`}
-                            key={device.deviceId}
-                          >
-                            {device.label}
-                          </option>
-                        ))}
-                      </select>
-                    )}
+                    <div className={`${styler('selectContainer')}`}>
+                      {audioInput.length > 0 && (
+                        <select
+                          name="selectedAudioInput"
+                          className={`${styler('select')}`}
+                          onChange={handleInputChange}
+                          value={values.selectedAudioInput}
+                        >
+                          {audioInput.map((device: InputDeviceInfo) => (
+                            <option
+                              value={device.deviceId}
+                              className={`${styler('selectInner')}`}
+                              key={device.deviceId}
+                            >
+                              {device.label}
+                            </option>
+                          ))}
+                        </select>
+                      )}
+                    </div>
                   </div>
-                </div>
+                )}
                 {/** Enabled this when the output is handled properly */}
                 <div className={`${styler('formInner')}`}>
                   <div className={`${styler('selectLabel')}`}>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -4,9 +4,8 @@ import { withStyles } from '@material-ui/core/styles';
 import {
   selectLocalMediaSettings,
   selectDevices,
-  selectLocalPeerRole,
   selectIsAllowedToPublish,
-  selectIsAllowedToSubscribe
+  selectIsAllowedToSubscribe,
 } from '@100mslive/hms-video-store';
 import { Button as TwButton } from '../Button';
 import { Text } from '../Text';
@@ -115,11 +114,10 @@ export const Settings = ({
 
   const storeInitialValues = useHMSStore(selectLocalMediaSettings);
   const devices = useHMSStore(selectDevices);
-  const {video: showVideo, audio: showAudio } = useHMSStore(selectIsAllowedToPublish);
+  const { video: showVideo, audio: showAudio } = useHMSStore(
+    selectIsAllowedToPublish,
+  );
   const isSubscribing = useHMSStore(selectIsAllowedToSubscribe);
-
-  const role = useHMSStore(selectLocalPeerRole);
-  
 
   const [open, setOpen] = useState(false);
   const [error, setError] = useState('');

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -290,7 +290,7 @@ export const Settings = ({
                   </div>
                 )}
                 {/** Enabled this when the output is handled properly */}
-                {isSubscribing && (
+                {isSubscribing && audioOutput.length > 0 && (
                   <>
                     <div className={`${styler('formInner')}`}>
                       <div className={`${styler('selectLabel')}`}>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -5,6 +5,8 @@ import {
   selectLocalMediaSettings,
   selectDevices,
   selectLocalPeerRole,
+  selectIsAllowedToPublish,
+  selectIsAllowedToSubscribe
 } from '@100mslive/hms-video-store';
 import { Button as TwButton } from '../Button';
 import { Text } from '../Text';
@@ -113,7 +115,11 @@ export const Settings = ({
 
   const storeInitialValues = useHMSStore(selectLocalMediaSettings);
   const devices = useHMSStore(selectDevices);
+  const {video: showVideo, audio: showAudio } = useHMSStore(selectIsAllowedToPublish);
+  const isSubscribing = useHMSStore(selectIsAllowedToSubscribe);
+
   const role = useHMSStore(selectLocalPeerRole);
+  
 
   const [open, setOpen] = useState(false);
   const [error, setError] = useState('');
@@ -172,16 +178,6 @@ export const Settings = ({
   const videoInput = devices['videoInput'] || [];
   const audioInput = devices['audioInput'] || [];
   const audioOutput = devices['audioOutput'] || [];
-  let showVideo = false;
-  let showAudio = false;
-  let isSubscribing = false;
-  if (role?.publishParams?.allowed) {
-    showVideo = role.publishParams.allowed.includes('video');
-    showAudio = role.publishParams.allowed.includes('audio');
-  }
-  if (role?.subscribeParams?.subscribeToRoles) {
-    isSubscribing = role.subscribeParams.subscribeToRoles.length > 0;
-  }
   const showSettings = [showVideo, showAudio, isSubscribing].some(val => !!val);
   if (!showSettings) {
     return null;

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -299,24 +299,22 @@ export const Settings = ({
                         </Text>
                       </div>
                       <div className={`${styler('selectContainer')}`}>
-                        {audioOutput.length > 0 && (
-                          <select
-                            name="selectedAudioOutput"
-                            className={`${styler('select')}`}
-                            onChange={handleInputChange}
-                            value={values.selectedAudioOutput}
-                          >
-                            {audioOutput.map((device: MediaDeviceInfo) => (
-                              <option
-                                value={device.deviceId}
-                                className={`${styler('select')}`}
-                                key={device.deviceId}
-                              >
-                                {device.label}
-                              </option>
-                            ))}
-                          </select>
-                        )}
+                        <select
+                          name="selectedAudioOutput"
+                          className={`${styler('select')}`}
+                          onChange={handleInputChange}
+                          value={values.selectedAudioOutput}
+                        >
+                          {audioOutput.map((device: MediaDeviceInfo) => (
+                            <option
+                              value={device.deviceId}
+                              className={`${styler('select')}`}
+                              key={device.deviceId}
+                            >
+                              {device.label}
+                            </option>
+                          ))}
+                        </select>
                       </div>
                     </div>
                     <div className={`${styler('formInner')}`}>

--- a/src/components/Settings/TestAudio.tsx
+++ b/src/components/Settings/TestAudio.tsx
@@ -32,7 +32,7 @@ const TestAudio = ({ outputDeviceId }: { outputDeviceId?: string }) => {
         onPlay={() => setPlaying(true)}
       ></audio>
 
-      <Button onClick={() => audioRef.current?.play()} disabled={playing}>
+      <Button onClick={() => audioRef.current?.play().catch(console.error)} disabled={playing}>
         {playing ? (
           <>
             <Text>Playing</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.1.59":
-  version "0.1.59"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.59.tgz#076f02de01060493a06d8e4dcdc72721c77d9da0"
-  integrity sha512-P0N60dWW4Yr2ym8zqPfZFaxSdYNTFXSg90dMFSlz/bR3PcAfmHH7E2H7HAwiR5HHkKI1abP4j9Mu3TD524nFNA==
+"@100mslive/hms-video-store@^0.1.60":
+  version "0.1.60"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.1.60.tgz#85d4da40be1c1f050353b8417b82b53e86be7268"
+  integrity sha512-afYzp1hpu7ASXebj1sQURyyTaxRJGWO0pnVTM2y47ab1PbgF88XJ1q4gGO4r1azG9DWwTcPMgM1ej2/nGI1eAg==
   dependencies:
     immer "^9.0.2"
     reselect "^4.0.0"


### PR DESCRIPTION
## Details

### Current Behaviour

- Even if the role is not allowed to publish audio/video, device selection is shown
- This results in the device dropdown being empty as permissions are not requested for that


### New Behaviour

- Show relevant device change based on the role


### Screenshots

For viewer role, it would be something like this
![image](https://user-images.githubusercontent.com/6763261/127092634-f2238352-103c-4c41-ad93-12a284d5e1e3.png)




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
