### PR TITLE
fix: hide settings icon if no permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ParticipantList/ParticipantInList.tsx
+++ b/src/components/ParticipantList/ParticipantInList.tsx
@@ -5,7 +5,8 @@ import { MicOffIcon, MicOnIcon, SettingsIcon } from '../Icons';
 import { Text } from '../Text';
 import { ParticipantListClasses } from './ParticipantProps';
 import { StylerType } from '../../types';
-import { HMSPeer } from '@100mslive/hms-video-store';
+import { HMSPeer, selectLocalPeerRole } from '@100mslive/hms-video-store';
+import { useHMSStore } from '../../hooks/HMSRoomProvider';
 
 interface PropsType {
   styler?: StylerType<ParticipantListClasses>;
@@ -22,6 +23,8 @@ export const ParticipantInList = ({
   onUserSettingsClick,
   isLocal,
 }: PropsType) => {
+  const localPeerRole = useHMSStore(selectLocalPeerRole);
+
   return (
     <span className={styler('menuItem')} role="menuitem">
       <div className={styler('menuText')}>
@@ -31,7 +34,7 @@ export const ParticipantInList = ({
         </Text>
       </div>
       <div className={styler('menuIconContainer')}>
-        {!isLocal && (
+        {!isLocal && localPeerRole?.permissions.changeRole && (
           <div>
             <Button
               iconOnly


### PR DESCRIPTION
## Details
- Hide settings icon if the user doesn't have permission to change roles.

### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
