### PR TITLE
fix: adjust spacing on control bar components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -43,8 +43,8 @@ export interface ControlBarProps {
 const defaultClasses: ControlBarClasses = {
   root:
     'flex bg-white dark:bg-black h-full items-center p-3 mr-2 ml-2 justify-center md:justify-between ',
-  leftRoot: 'flex justify-center justify-between w-10 md:w-44 z-10',
-  centerRoot: 'flex md:flex-1 mr-4 md:mr-0 justify-center md:-translate-x-5',
+  leftRoot: 'flex justify-center z-10 space-x-2 md:space-x-3',
+  centerRoot: 'flex md:flex-1 mr-4 md:mr-0 justify-center',
   rightRoot: '',
 };
 


### PR DESCRIPTION
## Details
adjust spacing on control bar components
- The left bar relied on fixed width to provide spacing, if the number of components increase or decrease, the spacing becomes inconsistent
- modified the CSS to allow for any number of components keeping the spacing consistent


### Screenshots

![image](https://user-images.githubusercontent.com/19195620/127301430-44430be7-98d7-4974-a0db-1c496cc7940b.png)


### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.



