### PR TITLE
fix: use material context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.8",
+  "version": "0.3.9",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build-storybook": "build-storybook -s public"
   },
   "peerDependencies": {
-    "@100mslive/hms-video": "^0.0.112",
+    "@100mslive/hms-video": "^0.0.113",
     "react": ">=16"
   },
   "husky": {
@@ -52,7 +52,7 @@
     }
   ],
   "devDependencies": {
-    "@100mslive/hms-video": "^0.0.112",
+    "@100mslive/hms-video": "^0.0.113",
     "@babel/core": "^7.13.14",
     "@rollup/plugin-image": "^2.0.6",
     "@size-limit/preset-small-lib": "^4.10.2",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.2.3",
+    "@100mslive/hms-video-store": "^0.2.4",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useMemo, useEffect } from 'react';
-import ClickAwayListener from 'react-click-away-listener';
+import React, { useMemo, useState, useEffect } from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
 import { useHMSTheme } from '../../hooks/HMSThemeProvider';
 import { hmsUiClassParserGenerator } from '../../utils/classes';
 import { DotMenuIcon } from '../Icons';
@@ -49,9 +50,9 @@ const defaultClasses: ContextMenuClasses = {
     'w-9 h-9 rounded-full bg-gray-300 cursor-pointer flex items-center justify-center z-20',
   triggerIcon: 'fill-current text-white w-5',
   menu:
-    'bg-white max-w-full dark:bg-gray-200 mt-2.5 rounded-lg w-44 h-auto max-h-15 py-2 text-white z-20',
+    'bg-white max-w-full dark:bg-gray-200 mt-2.5 rounded-lg w-44 h-auto max-h-15 py-2 overflow-y-auto text-white z-20',
   menuItem:
-    'flex flex-row flex-wrap items-center px-2 hover:bg-gray-600 dark:hover:bg-gray-300 cursor-pointer',
+    'w-full flex flex-row flex-wrap items-center px-2 my-1 hover:bg-gray-600 dark:hover:bg-gray-300 cursor-pointer',
   menuIcon: 'w-6 mr-2 fill-current text-gray-100 dark:text-white',
   menuTitle: 'text-gray-100 dark:text-white text-base w-9/12 min-w-0 truncate',
   menuItemChildren: 'w-11/12 ml-1 justify-self-center',
@@ -63,8 +64,6 @@ export const ContextMenuItem = ({
   icon,
   label,
   children,
-  onClick,
-  active,
 }: ContextMenuItemProps) => {
   const { tw } = useHMSTheme();
   const styler = useMemo(
@@ -79,19 +78,13 @@ export const ContextMenuItem = ({
   );
 
   return (
-    <div
-      className={`${styler('menuItem')} ${
-        active ? styler('menuItemActive') : ''
-      }`}
-      onClick={onClick}
-      style={{ minHeight: 40 }}
-    >
+    <>
       {icon && <span className={styler('menuIcon')}>{icon}</span>}
       <span className={styler('menuTitle')} title={label}>
         {label}
       </span>
       {children && <div className={styler('menuItemChildren')}>{children}</div>}
-    </div>
+    </>
   );
 };
 
@@ -101,8 +94,9 @@ export const ContextMenu = ({
   menuOpen = false,
   onTrigger,
 }: ContextMenuProps) => {
-  const [open, setOpen] = useState(menuOpen);
   const { tw } = useHMSTheme();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [open, setOpen] = useState(false);
   const styler = useMemo(
     () =>
       hmsUiClassParserGenerator<ContextMenuClasses>({
@@ -111,8 +105,14 @@ export const ContextMenu = ({
         defaultClasses,
         tag: 'hmsui-contextmenu',
       }),
-    [],
+    [classes],
   );
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setOpen(true);
+    setAnchorEl(event.currentTarget);
+    onTrigger && onTrigger(true);
+  };
 
   useEffect(() => {
     setOpen(menuOpen);
@@ -125,20 +125,53 @@ export const ContextMenu = ({
 
   return (
     <div className={styler('root')}>
-      <div
-        className={styler('trigger')}
-        onClick={() => {
-          setOpen(!open);
-          onTrigger && onTrigger(!open);
-        }}
-      >
-        <DotMenuIcon className={styler('triggerIcon')} />
+      <div className={styler('trigger')} onClick={handleClick}>
+        <DotMenuIcon
+          className={styler('triggerIcon')}
+          aria-label="more"
+          aria-controls="context-menu"
+          aria-haspopup="true"
+        />
       </div>
-      {open && (
-        <ClickAwayListener onClickAway={() => setOpen(false)}>
-          <div className={`${styler('menu')}`}>{children}</div>
-        </ClickAwayListener>
-      )}
+      <Menu
+        id="context-menu"
+        anchorEl={anchorEl}
+        open={open}
+        autoFocus={false}
+        getContentAnchorEl={null}
+        onClose={() => {
+          setOpen(false);
+          onTrigger && onTrigger(false);
+        }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        classes={{ paper: styler('menu') }}
+      >
+        {React.Children.map(children, child => {
+          return (
+            <MenuItem
+              key={child.key}
+              classes={{
+                root: `${styler('menuItem')}  ${
+                  child.props.active ? styler('menuItemActive') : ''
+                }`,
+              }}
+              style={{
+                minHeight: 40,
+              }}
+              onClick={child.props.onClick}
+            >
+              {child}
+            </MenuItem>
+          );
+        })}
+      </Menu>
     </div>
   );
 };

--- a/src/components/ContextMenu/index.css
+++ b/src/components/ContextMenu/index.css
@@ -1,7 +1,3 @@
 .hmsui-contextmenu-menu {
   box-shadow: 0px 11px 26px rgba(0, 0, 0, 0.2);
 }
-
-.hmsui-contextmenu-root {
-  width: calc(100% - 0.5rem);
-}

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react';
+import ClickAwayListener from 'react-click-away-listener';
 import {
   HMSPeer,
   selectCameraStreamByPeerID,
@@ -136,6 +137,7 @@ export const VideoTile = ({
   const { appBuilder, tw } = useHMSTheme();
   const hmsActions = useHMSActions();
   const [showMenu, setShowMenu] = useState(false);
+  const [showTrigger, setShowTrigger] = useState(false);
   const styler = useMemo(
     () =>
       hmsUiClassParserGenerator<VideoTileClasses>({
@@ -283,80 +285,92 @@ export const VideoTile = ({
     aspectRatio && objectFit === 'cover' ? aspectRatio : { width, height };
 
   return (
-    <div className={styler('root')}>
-      {!peer.isLocal && (
-        <ContextMenu
-          classes={{ root: 'invisible' }}
-          menuOpen={showMenu}
-          onTrigger={value => setShowMenu(value)}
-        >
-          {getMenuItems()}
-        </ContextMenu>
-      )}
-      {((impliedAspectRatio.width && impliedAspectRatio.height) ||
-        objectFit === 'contain') && (
-        <div
-          className={`${styler('videoContainer')} ${
-            displayShape === 'circle' ? styler('videoContainerCircle') : ''
-          } `}
-          style={
-            objectFit !== 'contain'
-              ? {
-                  aspectRatio: `${
-                    displayShape === 'rectangle'
-                      ? impliedAspectRatio.width / impliedAspectRatio.height
-                      : 1
-                  }`,
-                }
-              : { objectFit: 'contain', width: '100%', height: '100%' }
-          }
-        >
-          {/* TODO this doesn't work in Safari and looks ugly with contain*/}
-          <Video
-            peerId={peer.id}
-            hmsVideoTrack={hmsVideoTrack}
-            videoTrack={videoTrack}
-            objectFit={objectFit}
-            isLocal={peer.isLocal}
-            showAudioLevel={showAudioLevel}
-            audioLevel={audioLevel}
-            audioLevelDisplayType={audioLevelDisplayType}
-            audioLevelDisplayColor={audioLevelDisplayColor}
-            displayShape={displayShape}
-          />
-          {isVideoMuted && (
-            <div
-              className={`${styler('avatarContainer')} ${
-                displayShape === 'circle' ? styler('avatarContainerCircle') : ''
-              }`}
-            >
-              <Avatar
-                label={peer.name}
-                size={compact ? 'sm' : 'xl'}
-                avatarType={avatarType}
-              />
-            </div>
-          )}
-          {controlsComponent ? (
-            controlsComponent
-          ) : (
-            // TODO circle controls are broken now
-            <VideoTileControls
+    <ClickAwayListener onClickAway={() => setShowTrigger(false)}>
+      <div
+        className={styler('root')}
+        onMouseEnter={() => setShowTrigger(true)}
+        onMouseLeave={() => {
+          setShowTrigger(false);
+        }}
+      >
+        {!peer.isLocal && (
+          <ContextMenu
+            classes={{
+              root: showMenu || showTrigger ? 'visible' : 'invisible',
+            }}
+            menuOpen={showMenu}
+            onTrigger={value => setShowMenu(value)}
+          >
+            {getMenuItems()}
+          </ContextMenu>
+        )}
+        {((impliedAspectRatio.width && impliedAspectRatio.height) ||
+          objectFit === 'contain') && (
+          <div
+            className={`${styler('videoContainer')} ${
+              displayShape === 'circle' ? styler('videoContainerCircle') : ''
+            } `}
+            style={
+              objectFit !== 'contain'
+                ? {
+                    aspectRatio: `${
+                      displayShape === 'rectangle'
+                        ? impliedAspectRatio.width / impliedAspectRatio.height
+                        : 1
+                    }`,
+                  }
+                : { objectFit: 'contain', width: '100%', height: '100%' }
+            }
+          >
+            {/* TODO this doesn't work in Safari and looks ugly with contain*/}
+            <Video
+              peerId={peer.id}
+              hmsVideoTrack={hmsVideoTrack}
+              videoTrack={videoTrack}
+              objectFit={objectFit}
               isLocal={peer.isLocal}
-              label={label}
-              isAudioMuted={isAudioMuted}
-              showAudioMuteStatus={showAudioMuteStatus}
-              showGradient={displayShape === 'circle'}
-              allowRemoteMute={allowRemoteMute}
-              showAudioLevel={
-                showAudioLevel && audioLevelDisplayType !== 'border'
-              }
-              audioLevelDisplayType={audioLevelDisplayType}
+              showAudioLevel={showAudioLevel}
               audioLevel={audioLevel}
+              audioLevelDisplayType={audioLevelDisplayType}
+              audioLevelDisplayColor={audioLevelDisplayColor}
+              displayShape={displayShape}
             />
-          )}
-        </div>
-      )}
-    </div>
+            {isVideoMuted && (
+              <div
+                className={`${styler('avatarContainer')} ${
+                  displayShape === 'circle'
+                    ? styler('avatarContainerCircle')
+                    : ''
+                }`}
+              >
+                <Avatar
+                  label={peer.name}
+                  size={compact ? 'sm' : 'xl'}
+                  avatarType={avatarType}
+                />
+              </div>
+            )}
+            {controlsComponent ? (
+              controlsComponent
+            ) : (
+              // TODO circle controls are broken now
+              <VideoTileControls
+                isLocal={peer.isLocal}
+                label={label}
+                isAudioMuted={isAudioMuted}
+                showAudioMuteStatus={showAudioMuteStatus}
+                showGradient={displayShape === 'circle'}
+                allowRemoteMute={allowRemoteMute}
+                showAudioLevel={
+                  showAudioLevel && audioLevelDisplayType !== 'border'
+                }
+                audioLevelDisplayType={audioLevelDisplayType}
+                audioLevel={audioLevel}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </ClickAwayListener>
   );
 };

--- a/src/components/VideoTile/index.css
+++ b/src/components/VideoTile/index.css
@@ -3,7 +3,3 @@
   visibility: visible;
   max-height: 60px;
 }
-
-.hmsui-videoTile-showControlsOnHoverParent:hover .hmsui-contextmenu-root {
-  visibility: visible;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.3.tgz#aebea1393a61f4f61d69da55e49a126dd8bf30c9"
-  integrity sha512-/a0CxyR1pQ/7LwR4hokgmUzhGioqj0rwlcDWw6+HuQurRZmd9WuOHADDexR3jhf00lRfuiC2uSrlpN00It8abA==
+"@100mslive/hms-video-store@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.4.tgz#8946d1b535aab1b7c186eeab357c08501adc8538"
+  integrity sha512-XnOdMWJB9OXmYUB1m31pKbX+S7SHKA8YkQn/OK2iXZxYDMAxaWCtQHVctsA3Tpw7ECy5M2c5uR5XU14rteh0JQ==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"
     zustand "3.5.7"
 
-"@100mslive/hms-video@^0.0.112":
-  version "0.0.112"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.112.tgz#ad854ca46db44585902d849b2152c3b046d4d6a4"
-  integrity sha512-2rbn+CVhqJOLsxSLr/7SnSYYKiFW7PHEXY0sHlOpsncnsnLN2bsTasMJ1YPAnZUDOp6MwAWTQD3JHlwOfI8ViA==
+"@100mslive/hms-video@^0.0.113":
+  version "0.0.113"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.113.tgz#9c8317c1c507471dabee618f555bd56ec4731abd"
+  integrity sha512-cljyrWPSdN4cCpl1yObdPW3FLdaV2Zt49+BZLJLmw6W3QyJkdVNvNFWsPPgEBlyGdqlXphm3yQd5myyUdwFnPw==
   dependencies:
     events "^3.3.0"
     sdp-transform "^2.14.1"


### PR DESCRIPTION

### Current Behaviour

- Context Menu doesn;t show properly when tile is small
- Context Menu is not cutoff when tile is at the bottom


### New Behaviour

- Most cases are handled automatically by using material context menu



### Screenshots

![image](https://user-images.githubusercontent.com/6763261/127847016-8590e242-e842-41fd-b57e-6c585ff9c2ae.png)



### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
