### PR TITLE
fix: show correct selected devices in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.12",
+  "version": "0.3.13",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, useMemo, useState } from 'react';
+import React, { ChangeEventHandler, useEffect, useMemo, useState } from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import { withStyles } from '@material-ui/core/styles';
 import {
@@ -154,6 +154,33 @@ export const Settings = ({
   const handleClose = () => {
     setOpen(false);
   };
+
+  useEffect(() => {
+    if (values.selectedAudioInput !== initialValues?.selectedAudioInput) {
+      setValues({
+        ...values,
+        selectedAudioInput: initialValues?.selectedAudioInput,
+      });
+    }
+  }, [initialValues.selectedAudioInput, values.selectedAudioInput]);
+
+  useEffect(() => {
+    if (values.selectedAudioOutput !== initialValues?.selectedAudioOutput) {
+      setValues({
+        ...values,
+        selectedAudioOutput: initialValues?.selectedAudioOutput,
+      });
+    }
+  }, [initialValues.selectedAudioOutput, values.selectedAudioOutput]);
+
+  useEffect(() => {
+    if (values.selectedVideoInput !== initialValues?.selectedVideoInput) {
+      setValues({
+        ...values,
+        selectedVideoInput: initialValues?.selectedVideoInput,
+      });
+    }
+  }, [initialValues.selectedVideoInput, values.selectedVideoInput]);
 
   const handleInputChange: ChangeEventHandler<any> = event => {
     const newValues = { ...values };


### PR DESCRIPTION
### Current Behaviour

- On Device changes, Settings does not show the correct selected device

### New Behaviour

- Updating settings whenever the store value changes



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
