### PR TITLE
fix: Button disabled(for preview)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.15",
+  "version": "0.3.17",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -209,6 +209,7 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
   return (
     <button
       type="button"
+      disabled={disabled}
       className={`${className} icon-size-${size}`}
       {...props}
     >

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -216,7 +216,7 @@ export const Preview = ({
           icon={inProgress ? <ProgressIcon /> : undefined}
           disabled={inProgress || roomState === HMSRoomState.Connecting}
           onClick={async () => {
-            if (inProgress) {
+            if (inProgress || roomState === HMSRoomState.Connecting) {
               return;
             }
             if (!name || !name.replace(/\u200b/g, ' ').trim()) {


### PR DESCRIPTION
## Details
Don't allow clicking disabled preview button to avoid joining when preview is in progress

### Current Behaviour
Clicking disabled button could trigger onClick



### New Behaviour
Clicking disabled button doesn't do anything



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
