### PR TITLE
fix: broadcast messages, unread count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.25",
+  "version": "0.3.26",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.2.12",
+    "@100mslive/hms-video-store": "^0.2.13",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -2,15 +2,14 @@ import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useInView } from 'react-intersection-observer';
 import {
   HMSMessage,
-  selectHMSMessagesByPeerID,
-  selectHMSMessagesByRole,
+  selectMessagesByPeerID,
+  selectMessagesByRole,
   selectPeerNameByID,
   selectHMSBroadcastMessages,
-  selectUnreadHMSMessagesCount,
-  selectHMSBroadcastMessagesUnreadCount,
+  selectBroadcastMessagesUnreadCount,
   HMSMessageInput,
-  selectHMSMessagesUnreadCountByRole,
-  selectHMSMessagesUnreadCountByPeerID,
+  selectMessagesUnreadCountByRole,
+  selectMessagesUnreadCountByPeerID,
 } from '@100mslive/hms-video-store';
 import { CloseIcon, DownCaratIcon, PeopleIcon, SendIcon } from '../Icons';
 import { Button } from '../Button';
@@ -131,24 +130,22 @@ export const ChatBox = ({
     [],
   );
   const storeMessages = useHMSStore(selectHMSBroadcastMessages);
-  const unreadMessagesCount = useHMSStore(
-    selectHMSBroadcastMessagesUnreadCount,
-  );
+  const unreadMessagesCount = useHMSStore(selectBroadcastMessagesUnreadCount);
   const hmsActions = useHMSActions();
   const [selection, setSelection] = useState({ role: '', peerId: '' });
   const [showChatSelection, setShowChatSelection] = useState(false);
   const selectedPeerName = useHMSStore(selectPeerNameByID(selection.peerId));
   const selectedPeerMessages = useHMSStore(
-    selectHMSMessagesByPeerID(selection.peerId),
+    selectMessagesByPeerID(selection.peerId),
   );
   const selectedRoleMessages = useHMSStore(
-    selectHMSMessagesByRole(selection.role),
+    selectMessagesByRole(selection.role),
   );
   const unreadCountByRole = useHMSStore(
-    selectHMSMessagesUnreadCountByRole(selection.role),
+    selectMessagesUnreadCountByRole(selection.role),
   );
   const unreadCountByPeerID = useHMSStore(
-    selectHMSMessagesUnreadCountByPeerID(selection.peerId),
+    selectMessagesUnreadCountByPeerID(selection.peerId),
   );
 
   messages = messages || storeMessages;

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -129,34 +129,25 @@ export const ChatBox = ({
       }),
     [],
   );
-  const storeMessages = useHMSStore(selectBroadcastMessages);
-  const unreadMessagesCount = useHMSStore(selectBroadcastMessagesUnreadCount);
   const hmsActions = useHMSActions();
   const [selection, setSelection] = useState({ role: '', peerId: '' });
   const [showChatSelection, setShowChatSelection] = useState(false);
   const selectedPeerName = useHMSStore(selectPeerNameByID(selection.peerId));
-  const selectedPeerMessages = useHMSStore(
-    selectMessagesByPeerID(selection.peerId),
-  );
-  const selectedRoleMessages = useHMSStore(
-    selectMessagesByRole(selection.role),
-  );
-  const unreadCountByRole = useHMSStore(
-    selectMessagesUnreadCountByRole(selection.role),
-  );
-  const unreadCountByPeerID = useHMSStore(
-    selectMessagesUnreadCountByPeerID(selection.peerId),
-  );
+  const storeMessageSelector = selection.role
+    ? selectMessagesByRole(selection.role)
+    : selection.peerId
+    ? selectMessagesByPeerID(selection.peerId)
+    : selectBroadcastMessages;
+  const storeUnreadMessageCountSelector = selection.role
+    ? selectMessagesUnreadCountByRole(selection.role)
+    : selection.peerId
+    ? selectMessagesUnreadCountByPeerID(selection.peerId)
+    : selectBroadcastMessagesUnreadCount;
+
+  const storeMessages = useHMSStore(storeMessageSelector) || [];
+  const unreadCount = useHMSStore(storeUnreadMessageCountSelector);
 
   messages = messages || storeMessages;
-  let unreadCount = unreadMessagesCount;
-  if (selection.peerId) {
-    messages = selectedPeerMessages || [];
-    unreadCount = unreadCountByPeerID;
-  } else if (selection.role) {
-    messages = selectedRoleMessages || [];
-    unreadCount = unreadCountByRole;
-  }
 
   const sendMessage = (message: string) => {
     const messageInput = {

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -5,9 +5,7 @@ import {
   selectHMSMessagesByPeerID,
   selectHMSMessagesByRole,
   selectPeerNameByID,
-} from '@100mslive/hms-video-store';
-import {
-  selectHMSMessages,
+  selectHMSBroadcastMessages,
   selectUnreadHMSMessagesCount,
   HMSMessageInput,
 } from '@100mslive/hms-video-store';
@@ -129,7 +127,7 @@ export const ChatBox = ({
       }),
     [],
   );
-  const storeMessages = useHMSStore(selectHMSMessages);
+  const storeMessages = useHMSStore(selectHMSBroadcastMessages);
   const unreadMessagesCount = useHMSStore(selectUnreadHMSMessagesCount);
   const hmsActions = useHMSActions();
   const [selection, setSelection] = useState({ role: '', peerId: '' });
@@ -179,9 +177,14 @@ export const ChatBox = ({
     }
   }, [messages]);
 
-  if (messagesEndInView && unreadMessagesCount != 0) {
-    hmsActions.setMessageRead(true);
-  }
+  useEffect(() => {
+    if (messagesEndInView) {
+      // Mark only crrent view messages as read
+      messages?.forEach(message => {
+        hmsActions.setMessageRead(true, message.id);
+      });
+    }
+  }, [selection.role, selection.peerId, messages, messagesEndInView]);
 
   return (
     <React.Fragment>

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -7,7 +7,10 @@ import {
   selectPeerNameByID,
   selectHMSBroadcastMessages,
   selectUnreadHMSMessagesCount,
+  selectHMSBroadcastMessagesUnreadCount,
   HMSMessageInput,
+  selectHMSMessagesUnreadCountByRole,
+  selectHMSMessagesUnreadCountByPeerID,
 } from '@100mslive/hms-video-store';
 import { CloseIcon, DownCaratIcon, PeopleIcon, SendIcon } from '../Icons';
 import { Button } from '../Button';
@@ -128,7 +131,9 @@ export const ChatBox = ({
     [],
   );
   const storeMessages = useHMSStore(selectHMSBroadcastMessages);
-  const unreadMessagesCount = useHMSStore(selectUnreadHMSMessagesCount);
+  const unreadMessagesCount = useHMSStore(
+    selectHMSBroadcastMessagesUnreadCount,
+  );
   const hmsActions = useHMSActions();
   const [selection, setSelection] = useState({ role: '', peerId: '' });
   const [showChatSelection, setShowChatSelection] = useState(false);
@@ -139,12 +144,21 @@ export const ChatBox = ({
   const selectedRoleMessages = useHMSStore(
     selectHMSMessagesByRole(selection.role),
   );
+  const unreadCountByRole = useHMSStore(
+    selectHMSMessagesUnreadCountByRole(selection.role),
+  );
+  const unreadCountByPeerID = useHMSStore(
+    selectHMSMessagesUnreadCountByPeerID(selection.peerId),
+  );
 
   messages = messages || storeMessages;
+  let unreadCount = unreadMessagesCount;
   if (selection.peerId) {
     messages = selectedPeerMessages || [];
+    unreadCount = unreadCountByPeerID;
   } else if (selection.role) {
     messages = selectedRoleMessages || [];
+    unreadCount = unreadCountByRole;
   }
 
   const sendMessage = (message: string) => {
@@ -290,7 +304,7 @@ export const ChatBox = ({
         </div>
         {/* footer */}
         <div className={styler('footer')}>
-          {unreadMessagesCount !== 0 && (
+          {unreadCount !== 0 && (
             <div className={styler('unreadMessagesContainer')}>
               <div
                 className={styler('unreadMessagesInner')}
@@ -298,7 +312,7 @@ export const ChatBox = ({
                   scrollToBottom(messageListRef, scrollAnimation);
                 }}
               >
-                {`New message${unreadMessagesCount > 1 ? 's' : ''}`}
+                {`New message${unreadCount > 1 ? 's' : ''}`}
                 <DownCaratIcon className={styler('unreadIcon')} />
               </div>
             </div>

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -5,7 +5,7 @@ import {
   selectMessagesByPeerID,
   selectMessagesByRole,
   selectPeerNameByID,
-  selectHMSBroadcastMessages,
+  selectBroadcastMessages,
   selectBroadcastMessagesUnreadCount,
   HMSMessageInput,
   selectMessagesUnreadCountByRole,
@@ -129,7 +129,7 @@ export const ChatBox = ({
       }),
     [],
   );
-  const storeMessages = useHMSStore(selectHMSBroadcastMessages);
+  const storeMessages = useHMSStore(selectBroadcastMessages);
   const unreadMessagesCount = useHMSStore(selectBroadcastMessagesUnreadCount);
   const hmsActions = useHMSActions();
   const [selection, setSelection] = useState({ role: '', peerId: '' });

--- a/src/components/ChatBox/ChatSelector.tsx
+++ b/src/components/ChatBox/ChatSelector.tsx
@@ -3,9 +3,9 @@ import {
   selectAvailableRoleNames,
   selectRemotePeers,
   HMSPeer,
-  selectHMSMessagesUnreadCountByRole,
-  selectHMSMessagesUnreadCountByPeerID,
-  selectHMSBroadcastMessagesUnreadCount,
+  selectMessagesUnreadCountByRole,
+  selectMessagesUnreadCountByPeerID,
+  selectBroadcastMessagesUnreadCount,
 } from '@100mslive/hms-video-store';
 import { useHMSStore } from '../../hooks/HMSRoomProvider';
 import { useHMSTheme } from '../../hooks/HMSThemeProvider';
@@ -64,7 +64,7 @@ const ChatSelectorRole = ({
   styler,
   onChange,
 }: ChatSelectorRoleProps) => {
-  const unreadCount = useHMSStore(selectHMSMessagesUnreadCountByRole(role));
+  const unreadCount = useHMSStore(selectMessagesUnreadCountByRole(role));
   return (
     <div
       className={`${styler('item')} ${styler('itemHover')}`}
@@ -82,9 +82,7 @@ const ChatSelectorPeer = ({
   styler,
   onChange,
 }: ChatSelectorPeerProps) => {
-  const unreadCount = useHMSStore(
-    selectHMSMessagesUnreadCountByPeerID(peer.id),
-  );
+  const unreadCount = useHMSStore(selectMessagesUnreadCountByPeerID(peer.id));
   return (
     <div
       className={`${styler('item')} ${styler('itemHover')}`}
@@ -105,8 +103,6 @@ const ChatSelectorPeer = ({
 
 export const ChatSelector = ({
   show = false,
-  selectedPeerID,
-  selectedRole,
   classes,
   onChange,
 }: ChatSelectorProps) => {
@@ -123,7 +119,7 @@ export const ChatSelector = ({
   );
   const roles = useHMSStore(selectAvailableRoleNames);
   const peers = useHMSStore(selectRemotePeers);
-  const unreadCount = useHMSStore(selectHMSBroadcastMessagesUnreadCount);
+  const unreadCount = useHMSStore(selectBroadcastMessagesUnreadCount);
   const [search, setSearch] = useState('');
   const filteredPeers = peers.filter(peer => {
     if (!search.replace(/\u200b/g, ' ')) {

--- a/src/components/ChatBox/ChatSelector.tsx
+++ b/src/components/ChatBox/ChatSelector.tsx
@@ -82,7 +82,7 @@ const ChatSelectorPeer = ({
   styler,
   onChange,
 }: ChatSelectorPeerProps) => {
-  const unreadCount: number = useHMSStore(
+  const unreadCount = useHMSStore(
     selectHMSMessagesUnreadCountByPeerID(peer.id),
   );
   return (

--- a/src/components/ChatBox/ChatSelector.tsx
+++ b/src/components/ChatBox/ChatSelector.tsx
@@ -156,7 +156,7 @@ export const ChatSelector = ({
         </div>
         {roles.map(role => {
           return (
-            <ChatSelectorRole role={role} onChange={onChange} styler={styler} />
+            <ChatSelectorRole key={role} role={role} onChange={onChange} styler={styler} />
           );
         })}
         {(filteredPeers.length > 0 || search) && (
@@ -167,7 +167,7 @@ export const ChatSelector = ({
         )}
         {filteredPeers.map(peer => {
           return (
-            <ChatSelectorPeer peer={peer} onChange={onChange} styler={styler} />
+            <ChatSelectorPeer key={peer.id} peer={peer} onChange={onChange} styler={styler} />
           );
         })}
       </div>

--- a/src/storybook/store/SetUpFakeStore.ts
+++ b/src/storybook/store/SetUpFakeStore.ts
@@ -25,6 +25,6 @@ export function setUpFakeStore() {
     storyBookSDK.addTestPeerAndSpeaker(peerWithMute.peer);
   });
   fakeMessages.map(msg => {
-    storyBookSDK.sendMessage(msg.message, true);
+    storyBookSDK.sendMessage(msg.message);
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.2.12":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.12.tgz#8f0134d6cc191c8b2c74f7e17b99a02d05de5d68"
-  integrity sha512-CoGI5IPl7rBM2/ZMf/lKfFxrLtMiYj4rB3s70Sm7W8K9q+ZD4KcvPT5X4RBIhlBoDGQkpg99cSLEmO4ozMjvxw==
+"@100mslive/hms-video-store@^0.2.13":
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.13.tgz#54bf0bd1d82614797f8641b8ca84e783b394b8d3"
+  integrity sha512-zA1YBuG/97g+zHnVATFIOLJ18HrN59ssuv01Ww/q6kKGGvNEPR/pjsOIyPB0dBc6cqk9ssfK4AlLFNU0f+vU4g==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"


### PR DESCRIPTION
## Details

### Current Behaviour

- Private messages are shown in everyone.


### New Behaviour

- Show only broadcast messages for everyone
- Only mark messages read if the relevant view is open



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
