### PR TITLE
feat: Add menu item for remove peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.27",
+  "version": "0.3.28",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.2.15",
+    "@100mslive/hms-video-store": "^0.2.16",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -56,7 +56,7 @@ const defaultClasses: ContextMenuClasses = {
   menuItem:
     'w-full flex flex-row flex-wrap items-center px-2 my-1 hover:bg-gray-600 dark:hover:bg-gray-300 cursor-pointer',
   menuIcon: 'w-6 mr-2 fill-current text-gray-100 dark:text-white',
-  menuTitle: 'text-gray-100 dark:text-white text-base w-9/12 min-w-0 truncate',
+  menuTitle: 'text-gray-100 dark:text-white text-base min-w-0 truncate',
   menuItemChildren: 'w-11/12 ml-1 justify-self-center',
   menuItemActive: 'bg-gray-600 dark:bg-gray-300',
 };

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -250,23 +250,27 @@ export const VideoTile = ({
   const getMenuItems = useCallback(() => {
     const children: JSX.Element[] = [];
 
-    children.push(
-      <ContextMenuItem
-        icon={storeHmsVideoTrack?.enabled ? <CamOnIcon /> : <CamOffIcon />}
-        label={`${storeHmsVideoTrack?.enabled ? 'Mute' : 'Unmute'} Video`}
-        key={100}
-        onClick={() => toggleTrackEnabled(storeHmsVideoTrack)}
-      />,
-    );
+    if (!showScreen) {
+      children.push(
+        <ContextMenuItem
+          icon={storeHmsVideoTrack?.enabled ? <CamOnIcon /> : <CamOffIcon />}
+          label={`${storeHmsVideoTrack?.enabled ? 'Mute' : 'Unmute'} Video`}
+          key={storeHmsVideoTrack?.id}
+          onClick={() => toggleTrackEnabled(storeHmsVideoTrack)}
+        />,
+      );
+    }
 
-    children.push(
-      <ContextMenuItem
-        icon={storeHmsAudioTrack?.enabled ? <MicOnIcon /> : <MicOffIcon />}
-        label={`${storeHmsAudioTrack?.enabled ? 'Mute' : 'Unmute'} Audio`}
-        key={101}
-        onClick={() => toggleTrackEnabled(storeHmsAudioTrack)}
-      />,
-    );
+    if (showScreen && !!screenshareAudioTrack) {
+      children.push(
+        <ContextMenuItem
+          icon={storeHmsAudioTrack?.enabled ? <MicOnIcon /> : <MicOffIcon />}
+          label={`${storeHmsAudioTrack?.enabled ? 'Mute' : 'Unmute'} Audio`}
+          key={storeHmsAudioTrack?.id}
+          onClick={() => toggleTrackEnabled(storeHmsAudioTrack)}
+        />,
+      );
+    }
 
     if (!showScreen || !!screenshareAudioTrack) {
       children.push(
@@ -298,6 +302,17 @@ export const VideoTile = ({
         </ContextMenuItem>,
       );
     }
+
+    if (!showScreen) {
+      children.push(
+        <ContextMenuItem
+          label="Remove from room"
+          key={peer.id}
+          onClick={() => hmsActions.removePeer(peer.id, '')}
+        />,
+      );
+    }
+
     children.push(
       ...layerDefinitions.map(({ layer, resolution }) => {
         return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.2.15":
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.15.tgz#47a9f46d51d69d0bbafffd3b117468ff5a482513"
-  integrity sha512-T9ZF3NZ9iV+9qW4fSwCcHrfgm3DvJBkZHcZU3cVnn50hIgh8CNEqzxWJz37LJPWFd7fe/ziRugNnp61tPDMCsA==
+"@100mslive/hms-video-store@^0.2.16":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.16.tgz#7a0e71a0dd3140a6033628096ba4e5dd7841abf5"
+  integrity sha512-TQtK2kc1H81gVYFcJVqbmZLHO3upFDZSsxZb9GLytb0RonbK3g4wUpIZDOn6JHdbza7/jNJnrWNyx1QTRtbnGg==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"


### PR DESCRIPTION
## Details
- Add context menu item for remove peer
- Don't show video remote mute for screenshare

### Current Behaviour
- Remote muting screenshare leads to blank tile




### New Behaviour
- Don't allow remote muting screenshare video



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
