### PR TITLE
fix: Show screen audio remote mute menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.28",
+  "version": "0.3.29",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -261,7 +261,7 @@ export const VideoTile = ({
       );
     }
 
-    if (showScreen && !!screenshareAudioTrack) {
+    if (storeHmsAudioTrack) {
       children.push(
         <ContextMenuItem
           icon={storeHmsAudioTrack?.enabled ? <MicOnIcon /> : <MicOffIcon />}


### PR DESCRIPTION
### Current Behaviour
- Audio remote mute menu item doesn't show up



### New Behaviour
- Audio remote mute menu item shows up when there's a store audio track



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [ ] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
