### PR TITLE
fix: Superpower buttons only when permitted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.29",
+  "version": "0.3.30",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -48,11 +48,11 @@
     }
   ],
   "peerDependencies": {
-    "@100mslive/hms-video": "^0.0.142",
+    "@100mslive/hms-video": "^0.0.145",
     "react": ">=16"
   },
   "devDependencies": {
-    "@100mslive/hms-video": "^0.0.142",
+    "@100mslive/hms-video": "^0.0.145",
     "@babel/core": "^7.13.14",
     "@rollup/plugin-image": "^2.0.6",
     "@size-limit/preset-small-lib": "^4.10.2",
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "^0.2.16",
+    "@100mslive/hms-video-store": "^0.2.18",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -13,6 +13,7 @@ import {
   selectSimulcastLayerByTrack,
   HMSTrack,
   selectTrackByID,
+  selectPermissions,
 } from '@100mslive/hms-video-store';
 import { HMSSimulcastLayer } from '@100mslive/hms-video';
 import { ContextMenu, ContextMenuItem } from '../ContextMenu';
@@ -200,6 +201,7 @@ export const VideoTile = ({
   const storeIsLocallyMuted = useHMSStore(
     selectIsAudioLocallyMuted(tileAudioTrack),
   );
+  const permissions = useHMSStore(selectPermissions);
 
   if (showAudioLevel === undefined) {
     showAudioLevel = !showScreen; // don't show audio levels for screenshare
@@ -250,7 +252,10 @@ export const VideoTile = ({
   const getMenuItems = useCallback(() => {
     const children: JSX.Element[] = [];
 
-    if (!showScreen) {
+    if (
+      !showScreen &&
+      (storeHmsVideoTrack?.enabled ? permissions?.mute : permissions?.unmute)
+    ) {
       children.push(
         <ContextMenuItem
           icon={storeHmsVideoTrack?.enabled ? <CamOnIcon /> : <CamOffIcon />}
@@ -261,7 +266,10 @@ export const VideoTile = ({
       );
     }
 
-    if (storeHmsAudioTrack) {
+    if (
+      storeHmsAudioTrack &&
+      (storeHmsAudioTrack?.enabled ? permissions?.mute : permissions?.unmute)
+    ) {
       children.push(
         <ContextMenuItem
           icon={storeHmsAudioTrack?.enabled ? <MicOnIcon /> : <MicOffIcon />}
@@ -303,7 +311,7 @@ export const VideoTile = ({
       );
     }
 
-    if (!showScreen) {
+    if (permissions?.removeOthers && !showScreen) {
       children.push(
         <ContextMenuItem
           label="Remove from room"
@@ -330,6 +338,9 @@ export const VideoTile = ({
     return children;
   }, [
     layerDefinitions,
+    storeHmsVideoTrack,
+    storeHmsAudioTrack,
+    permissions,
     showScreen,
     screenshareAudioTrack,
     tileAudioTrack,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,19 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@^0.2.16":
-  version "0.2.16"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.16.tgz#7a0e71a0dd3140a6033628096ba4e5dd7841abf5"
-  integrity sha512-TQtK2kc1H81gVYFcJVqbmZLHO3upFDZSsxZb9GLytb0RonbK3g4wUpIZDOn6JHdbza7/jNJnrWNyx1QTRtbnGg==
+"@100mslive/hms-video-store@^0.2.18":
+  version "0.2.18"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.18.tgz#6e0fdb8416b53c118d712cadbb2d1ebd48f029a9"
+  integrity sha512-g2gT8loxtw1RE9qyGQP6Y1HQi84AzfySc+oC38zgtq+3e4b+5Dqwnb6kz9XLvQukPIS1qqd+xazHp9UGc1k1TA==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"
     zustand "3.5.7"
 
-"@100mslive/hms-video@^0.0.142":
-  version "0.0.142"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.142.tgz#1d59c29e5152d15a666964746ba620702311a3ef"
-  integrity sha512-RiHfRiz+SNtB/vQjZpj6s9MCYasJRRN1aAKgvCnaru5AXQwVhco4+jQ8/tSJfOHRjwmx/N0eQNykH1tJiWPPvw==
+"@100mslive/hms-video@^0.0.145":
+  version "0.0.145"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video/-/hms-video-0.0.145.tgz#1be3077902f46f75928c3a29068b96acf75061a1"
+  integrity sha512-lT04741a2YM2YJSujbDTiivpgggJ3ccX74weH0oUp6s7GDTcBH8+4/cI4dTcF0PcPoEAN0QvS7hktJIUbxNaAg==
   dependencies:
     events "^3.3.0"
     sdp-transform "^2.14.1"


### PR DESCRIPTION
## Details
- Bump hms-video@0.0.145, hms-video-store@0.2.18
- Show superpower buttons only when permitted

### Current Behaviour
- Remote mute, remove peer buttons come up for unpermitted roles too.



### New Behaviour
- Superpower buttons only appear when role is permitted.



### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
