### PR TITLE
fix: preview video tile size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.34",
+  "version": "0.3.35",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useEffect, useState, useMemo, useRef, Fragment } from 'react';
 import { HMSConfig } from '@100mslive/hms-video';
 import {
   HMSRoomState,
@@ -154,92 +148,94 @@ export const Preview = ({
   };
 
   return (
-    // root
-    <div className={styler('root')}>
-      <div className={styler('containerRoot')}>
-        {/* header */}
-        <div className={styler('header')}>
-          {/* messageModal */}
-          <MessageModal
-            show={showModal}
-            title={error.title}
-            body={error.message}
-            onClose={() => {
-              if (error.allowJoin) {
-                setShowModal(false);
+    <Fragment>
+      {/* root */}
+      <div className={styler('root')}>
+        <div className={styler('containerRoot')}>
+          {/* header */}
+          <div className={styler('header')}>
+            {/* videoTile */}
+            {localPeer ? (
+              <VideoTile
+                {...videoTileProps}
+                peer={{ ...localPeer, name }}
+                objectFit="cover"
+                aspectRatio={{
+                  width: 1,
+                  height: 1,
+                }}
+                classes={videoTileClasses}
+                controlsComponent={
+                  <PreviewControls
+                    audioButtonOnClick={() => setAudioEnabled(!audioEnabled)}
+                    videoButtonOnClick={() => setVideoEnabled(!videoEnabled)}
+                    isAudioMuted={!audioEnabled}
+                    isVideoMuted={!videoEnabled}
+                    isAudioAllowed={isAllowedToPublish.audio}
+                    isVideoAllowed={isAllowedToPublish.video}
+                  />
+                }
+              />
+            ) : !error.title ? (
+              <ProgressIcon width="100" height="100" />
+            ) : null}
+          </div>
+          {/* helloDiv */}
+          <div className={styler('helloDiv')}>Hi There</div>
+          {/* nameDiv */}
+          <div className={styler('nameDiv')}>What's your name?</div>
+          {/* inputFieldRoot */}
+          <div className={styler('inputRoot')}>
+            <Input
+              ref={inputRef}
+              {...inputProps}
+              autoCorrect="off"
+              autoComplete="name"
+            />
+          </div>
+
+          {/* joinButton */}
+          <Button
+            variant="emphasized"
+            size="lg"
+            iconRight={inProgress || roomState === HMSRoomState.Connecting}
+            icon={inProgress ? <ProgressIcon /> : undefined}
+            disabled={inProgress || roomState === HMSRoomState.Connecting}
+            onClick={async () => {
+              if (inProgress || roomState === HMSRoomState.Connecting) {
                 return;
               }
-              errorOnClick();
-            }}
-          />
-          {/* videoTile */}
-          {localPeer ? (
-            <VideoTile
-              {...videoTileProps}
-              peer={{ ...localPeer, name }}
-              objectFit="cover"
-              aspectRatio={{
-                width: 1,
-                height: 1,
-              }}
-              classes={videoTileClasses}
-              controlsComponent={
-                <PreviewControls
-                  audioButtonOnClick={() => setAudioEnabled(!audioEnabled)}
-                  videoButtonOnClick={() => setVideoEnabled(!videoEnabled)}
-                  isAudioMuted={!audioEnabled}
-                  isVideoMuted={!videoEnabled}
-                  isAudioAllowed={isAllowedToPublish.audio}
-                  isVideoAllowed={isAllowedToPublish.video}
-                />
+              if (!name || !name.replace(/\u200b/g, ' ').trim()) {
+                inputRef.current && inputRef.current.focus();
+                setShowValidation(true);
+                return;
               }
-            />
-          ) : !error.title ? (
-            <ProgressIcon width="100" height="100" />
-          ) : null}
+              setInProgress(true);
+              await joinOnClick({
+                audioMuted: !audioEnabled,
+                videoMuted: !videoEnabled,
+                name,
+              });
+              setInProgress(false);
+            }}
+          >
+            Join
+          </Button>
         </div>
-        {/* helloDiv */}
-        <div className={styler('helloDiv')}>Hi There</div>
-        {/* nameDiv */}
-        <div className={styler('nameDiv')}>What's your name?</div>
-        {/* inputFieldRoot */}
-        <div className={styler('inputRoot')}>
-          <Input
-            ref={inputRef}
-            {...inputProps}
-            autoCorrect="off"
-            autoComplete="name"
-          />
-        </div>
-
-        {/* joinButton */}
-        <Button
-          variant="emphasized"
-          size="lg"
-          iconRight={inProgress || roomState === HMSRoomState.Connecting}
-          icon={inProgress ? <ProgressIcon /> : undefined}
-          disabled={inProgress || roomState === HMSRoomState.Connecting}
-          onClick={async () => {
-            if (inProgress || roomState === HMSRoomState.Connecting) {
-              return;
-            }
-            if (!name || !name.replace(/\u200b/g, ' ').trim()) {
-              inputRef.current && inputRef.current.focus();
-              setShowValidation(true);
-              return;
-            }
-            setInProgress(true);
-            await joinOnClick({
-              audioMuted: !audioEnabled,
-              videoMuted: !videoEnabled,
-              name,
-            });
-            setInProgress(false);
-          }}
-        >
-          Join
-        </Button>
       </div>
-    </div>
+      {/* messageModal */}
+      <MessageModal
+        show={showModal}
+        title={error.title}
+        body={error.message}
+        onClose={() => {
+          if (error.allowJoin) {
+            setShowModal(false);
+            return;
+          }
+          errorOnClick();
+        }}
+      />
+    </Fragment>
   );
 };


### PR DESCRIPTION
## Details
- https://100ms.atlassian.net/browse/HMS-3670
- https://100ms.atlassian.net/browse/HMS-3147

### Current Behaviour

- In preview video tile size is much smaller in safari

### New Behaviour

- Make it consistent with other browsers


### Screenshots
![image](https://user-images.githubusercontent.com/6763261/129864813-7746c8d1-f128-4b5d-b7ab-5ba7b92b440c.png)




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
