### PR TITLE
fix: remove peer text alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.36",
+  "version": "0.3.37",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -16,6 +16,7 @@ export interface ContextMenuClasses {
   menuIcon?: string;
   menuItemChildren?: string;
   menuItemActive?: string;
+  menuTitleContainer?: string;
 }
 
 export type ContextMenuItemClasses = Omit<
@@ -59,6 +60,7 @@ const defaultClasses: ContextMenuClasses = {
   menuTitle: 'text-gray-100 dark:text-white text-base min-w-0 truncate',
   menuItemChildren: 'w-11/12 ml-1 justify-self-center',
   menuItemActive: 'bg-gray-600 dark:bg-gray-300',
+  menuTitleContainer: 'w-full flex items-center',
 };
 
 export const ContextMenuItem = ({
@@ -81,10 +83,12 @@ export const ContextMenuItem = ({
 
   return (
     <>
-      {icon && <span className={styler('menuIcon')}>{icon}</span>}
-      <span className={styler('menuTitle')} title={label}>
-        {label}
-      </span>
+      <div className={styler('menuTitleContainer')}>
+        {icon && <span className={styler('menuIcon')}>{icon}</span>}
+        <span className={styler('menuTitle')} title={label}>
+          {label}
+        </span>
+      </div>
       {children && <div className={styler('menuItemChildren')}>{children}</div>}
     </>
   );

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -315,7 +315,11 @@ export const VideoTile = ({
     if (permissions?.removeOthers && !showScreen) {
       children.push(
         <ContextMenuItem
-          label="Remove from room"
+          label="Remove Participant"
+          classes={{
+            menuTitle: 'text-red-500 dark:text-red-500',
+            menuIcon: 'text-red-500 dark:text-red-500',
+          }}
           key={peer.id}
           icon={<RemovePeerIcon />}
           onClick={() => hmsActions.removePeer(peer.id, '')}


### PR DESCRIPTION
## Details

### Current Behaviour

- Remove participant alignment is not correct. Goes to next line

### New Behaviour

- Update remote participant text and color


### Screenshots

![image](https://user-images.githubusercontent.com/6763261/130025667-00eedc71-45be-4794-9e14-e8e0d4864322.png)



### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
