### PR TITLE
feat: Add toast errors for superpower actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.39",
+  "version": "0.3.40",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -117,7 +117,7 @@ export const ChatBox = ({
     return `${date.getHours()}:${minString}`;
   },
 }: ChatProps) => {
-  const { tw } = useHMSTheme();
+  const { tw, toast } = useHMSTheme();
   const styler = useMemo(
     () =>
       hmsUiClassParserGenerator<ChatBoxClasses>({
@@ -154,12 +154,16 @@ export const ChatBox = ({
       onSend(message);
       return;
     }
-    if (selection.role) {
-      await hmsActions.sendGroupMessage(message, [selection.role]);
-    } else if (selection.peerId) {
-      await hmsActions.sendDirectMessage(message, selection.peerId);
-    } else {
-      await hmsActions.sendBroadcastMessage(message);
+    try {
+      if (selection.role) {
+        await hmsActions.sendGroupMessage(message, [selection.role]);
+      } else if (selection.peerId) {
+        await hmsActions.sendDirectMessage(message, selection.peerId);
+      } else {
+        await hmsActions.sendBroadcastMessage(message);
+      }
+    } catch (error) {
+      toast(error.message);
     }
   };
   const [messageDraft, setMessageDraft] = useState('');

--- a/src/components/ChatBox/ChatBox.tsx
+++ b/src/components/ChatBox/ChatBox.tsx
@@ -149,17 +149,17 @@ export const ChatBox = ({
 
   messages = messages || storeMessages;
 
-  const sendMessage = (message: string) => {
+  const sendMessage = async (message: string) => {
     if (onSend) {
       onSend(message);
       return;
     }
     if (selection.role) {
-      hmsActions.sendGroupMessage(message, [selection.role]);
+      await hmsActions.sendGroupMessage(message, [selection.role]);
     } else if (selection.peerId) {
-      hmsActions.sendDirectMessage(message, selection.peerId);
+      await hmsActions.sendDirectMessage(message, selection.peerId);
     } else {
-      hmsActions.sendBroadcastMessage(message);
+      await hmsActions.sendBroadcastMessage(message);
     }
   };
   const [messageDraft, setMessageDraft] = useState('');
@@ -323,12 +323,12 @@ export const ChatBox = ({
             className={`${styler('chatInput')}`}
             placeholder="Write something here"
             value={messageDraft}
-            onKeyPress={event => {
+            onKeyPress={async event => {
               if (event.key === 'Enter') {
                 if (!event.shiftKey) {
                   event.preventDefault();
                   if (messageDraft.trim() !== '') {
-                    sendMessage(messageDraft);
+                    await sendMessage(messageDraft);
                     setMessageDraft('');
                   }
                 }
@@ -344,8 +344,8 @@ export const ChatBox = ({
             variant={'no-fill'}
             iconSize={'sm'}
             size="sm"
-            onClick={() => {
-              sendMessage(messageDraft);
+            onClick={async () => {
+              await sendMessage(messageDraft);
               setMessageDraft('');
             }}
           >

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -84,7 +84,7 @@ export const ParticipantList = ({
   classes,
   onToggle,
 }: ParticipantListProps) => {
-  const { tw } = useHMSTheme();
+  const { tw, toast } = useHMSTheme();
   const styler = useMemo(
     () =>
       hmsUiClassParserGenerator<ParticipantListClasses>({
@@ -128,7 +128,7 @@ export const ParticipantList = ({
     setSelectedRole(event.currentTarget.value);
   };
 
-  const handleSaveSettings = () => {
+  const handleSaveSettings = async () => {
     if (
       !selectedPeer ||
       !selectedRole ||
@@ -138,7 +138,11 @@ export const ParticipantList = ({
     }
 
     if (selectedPeer.roleName !== selectedRole) {
-      hmsActions.changeRole(selectedPeer.id, selectedRole, forceChange);
+      try {
+        await hmsActions.changeRole(selectedPeer.id, selectedRole, forceChange);
+      } catch (error) {
+        toast(error.message, {});
+      }
     }
 
     setSelectedPeer(null);

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -141,7 +141,7 @@ export const ParticipantList = ({
       try {
         await hmsActions.changeRole(selectedPeer.id, selectedRole, forceChange);
       } catch (error) {
-        toast(error.message, {});
+        toast(error.message);
       }
     }
 

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -193,7 +193,7 @@ export const VideoTile = ({
       try {
         await hmsActions.setRemoteTrackEnabled(track.id, !track.enabled);
       } catch (error) {
-        toast(error.message, {});
+        toast(error.message);
       }
     }
   };
@@ -330,7 +330,7 @@ export const VideoTile = ({
             try {
               await hmsActions.removePeer(peer.id, '');
             } catch (error) {
-              toast(error.message, {});
+              toast(error.message);
             }
           }}
         />,

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -144,7 +144,7 @@ export const VideoTile = ({
   avatarType,
   compact = false,
 }: VideoTileProps) => {
-  const { appBuilder, tw } = useHMSTheme();
+  const { appBuilder, tw, toast } = useHMSTheme();
   const hmsActions = useHMSActions();
   const [showMenu, setShowMenu] = useState(false);
   const [showTrigger, setShowTrigger] = useState(false);
@@ -188,9 +188,13 @@ export const VideoTile = ({
     setShowMenu(false);
   };
 
-  const toggleTrackEnabled = (track?: HMSTrack | null) => {
+  const toggleTrackEnabled = async (track?: HMSTrack | null) => {
     if (track) {
-      hmsActions.setRemoteTrackEnabled(track.id, !track.enabled);
+      try {
+        await hmsActions.setRemoteTrackEnabled(track.id, !track.enabled);
+      } catch (error) {
+        toast(error.message, {});
+      }
     }
   };
 
@@ -318,7 +322,13 @@ export const VideoTile = ({
           label="Remove from room"
           key={peer.id}
           icon={<RemovePeerIcon />}
-          onClick={() => hmsActions.removePeer(peer.id, '')}
+          onClick={async () => {
+            try {
+              await hmsActions.removePeer(peer.id, '');
+            } catch (error) {
+              toast(error.message, {});
+            }
+          }}
         />,
       );
     }

--- a/src/hooks/HMSThemeProvider.tsx
+++ b/src/hooks/HMSThemeProvider.tsx
@@ -15,10 +15,12 @@ export const HMSThemeProvider = ({
   config,
   children,
   appBuilder,
+  toast,
 }: {
   children: React.ReactNode;
   config: any;
   appBuilder: appBuilder;
+  toast?: (message: any, options: any) => any;
 }) => {
   if (isBrowser) {
     if (appBuilder.theme === 'dark') {
@@ -38,6 +40,7 @@ export const HMSThemeProvider = ({
         tw,
         tailwindConfig: twConfig,
         appBuilder,
+        toast: toast || console.log,
       }}
     >
       {children}

--- a/src/hooks/HMSThemeProvider.tsx
+++ b/src/hooks/HMSThemeProvider.tsx
@@ -20,7 +20,7 @@ export const HMSThemeProvider = ({
   children: React.ReactNode;
   config: any;
   appBuilder: appBuilder;
-  toast?: (message: any, options: any) => any;
+  toast?: (message: any, options?: any) => any;
 }) => {
   if (isBrowser) {
     if (appBuilder.theme === 'dark') {

--- a/src/hooks/interfaces/HMSThemeProvider.ts
+++ b/src/hooks/interfaces/HMSThemeProvider.ts
@@ -17,4 +17,5 @@ export default interface HMSThemeProps {
   tw: TW;
   tailwindConfig: any;
   appBuilder: appBuilder;
+  toast: (message: any, options: any) => any;
 }

--- a/src/hooks/interfaces/HMSThemeProvider.ts
+++ b/src/hooks/interfaces/HMSThemeProvider.ts
@@ -17,5 +17,5 @@ export default interface HMSThemeProps {
   tw: TW;
   tailwindConfig: any;
   appBuilder: appBuilder;
-  toast: (message: any, options: any) => any;
+  toast: (message: any, options?: any) => any;
 }


### PR DESCRIPTION
## Details
- Await and wrap superpower actions in try catch.
- Catch the error and toast the error message.
- Accept toast function from web app as prop in HMSThemeProvider.
- Provide to all components using useHMSTheme hook.

### Current Behaviour
- Superpower errors are uncaught.
- No way to toast from components



### New Behaviour
- Catch errors from superpower
- Use toast to display them



### Screenshots
![image](https://user-images.githubusercontent.com/64120992/130221298-0b1a67ab-7b53-4703-890f-fca1ad20e43e.png)




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
