### PR TITLE
fix: mweb UI fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.40",
+  "version": "0.3.41",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -69,8 +69,6 @@ const customClasses: ParticipantListClasses = {
   onIcon: 'hmsui-participantList-show-on-group-hover',
 };
 
-type RoleMap = Map<string, HMSPeerWithMuteStatus[]>;
-
 const HMSDialog = withStyles({
   paper: {
     borderRadius: '12px',
@@ -262,9 +260,8 @@ export const ParticipantList = ({
                       className={`${styler('menuSection')}`}
                       role="menuitem"
                     >
-                      {role === 'undefined' ? 'Unknown' : role}
-                      {rolesMap[role].length > 1 ? 's' : ''}{' '}
-                      {rolesMap[role].length}
+                      {role === 'undefined' ? 'Unknown' : role}(
+                      {rolesMap[role].length})
                     </span>
                     <div>
                       {rolesMap[role] &&

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -50,7 +50,7 @@ const defaultClasses: ParticipantListClasses = {
   onIcon: '',
   offIcon: '',
   dialogContainer:
-    'bg-white text-gray-100 dark:bg-gray-100 dark:text-white w-full p-4 rounded-xl',
+    'bg-white text-gray-100 dark:bg-gray-100 dark:text-white w-full md:w-96 p-4 rounded-xl',
   dialogHeader: 'flex items-center space-x-2',
   expanded: 'flex-1 min-w-0 truncate',
   textGray: 'text-gray-400',
@@ -75,7 +75,6 @@ const HMSDialog = withStyles({
   paper: {
     borderRadius: '12px',
     backgroundColor: 'inherit',
-    minWidth: '400px',
   },
 })(Dialog);
 

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -56,11 +56,11 @@ const defaultClasses: SettingsClasses = {
   dialogRoot: 'rounded-xl ',
   dialogContainer:
     'bg-white text-gray-100 dark:bg-gray-100 dark:text-white w-full p-2 overflow-y-auto rounded-xl',
-  dialogInner: 'text-2xl mb-3 p-2 flex justify-between',
+  dialogInner: 'text-2xl p-2 flex justify-between',
   titleContainer: 'flex items-center',
   titleIcon: 'pr-4',
   titleText: 'text-2xl leading-7',
-  formContainer: 'flex flex-wrap p-3 md:p-0 text-base mb-2 md:mb-0',
+  formContainer: 'flex flex-wrap p-3 pt-0 md:p-0 text-base md:mb-0',
   formInner: 'w-full flex flex-col md:flex-row my-1.5',
   selectLabel: 'w-full md:w-1/3 flex justify-start md:justify-end items-center',
   selectContainer:

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -226,7 +226,7 @@ export const Settings = ({
                               className={`${styler('selectInner')}`}
                               key={device.deviceId}
                             >
-                              {device.label} {device.deviceId}
+                              {device.label}
                             </option>
                           ))}
                         </select>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, useEffect, useMemo, useState } from 'react';
+import React, { ChangeEventHandler, useMemo, useState } from 'react';
 import Dialog from '@material-ui/core/Dialog';
 import { withStyles } from '@material-ui/core/styles';
 import {
@@ -60,10 +60,11 @@ const defaultClasses: SettingsClasses = {
   titleContainer: 'flex items-center',
   titleIcon: 'pr-4',
   titleText: 'text-2xl leading-7',
-  formContainer: 'flex flex-wrap text-base mb-2 md:mb-0',
-  formInner: 'w-full flex my-1.5',
-  selectLabel: 'w-1/3 flex justify-end items-center',
-  selectContainer: 'rounded-lg w-1/2 bg-gray-600 dark:bg-gray-200 p-2 mx-2',
+  formContainer: 'flex flex-wrap p-3 md:p-0 text-base mb-2 md:mb-0',
+  formInner: 'w-full flex flex-col md:flex-row my-1.5',
+  selectLabel: 'w-full md:w-1/3 flex justify-start md:justify-end items-center',
+  selectContainer:
+    'rounded-lg w-full md:w-1/2 bg-gray-600 dark:bg-gray-200 p-2 mx-0 my-2 md:my-0 md:mx-2',
   select:
     'rounded-lg w-full h-full bg-gray-600 dark:bg-gray-200 focus:outline-none',
   selectInner: 'p-4',
@@ -75,7 +76,7 @@ const defaultClasses: SettingsClasses = {
   sliderLabel: 'text-right',
   slider: 'rounded-lg w-1/2  p-2 mx-2 flex my-1 items-center ',
   errorContainer: 'flex justify-center items-center w-full px-8 py-4',
-  testAudioContainer: 'mx-2',
+  testAudioContainer: 'mx-0 my-2 md:my-0 md:mx-2',
 };
 
 const customClasses: SettingsClasses = {


### PR DESCRIPTION
## Details

### Current Behaviour

- ChangeRole modal overflowing width
- Camera label too big in mobile
- Settings are too small on mobile


### New Behaviour

- Fix ChangeRole modal with
- Remove deviceid from camera name
- Adjust settings UI, make it vertical on mobile



### Screenshots

![image](https://user-images.githubusercontent.com/6763261/130488276-113273e8-71e7-4a42-a971-d3247a44f225.png)
![image](https://user-images.githubusercontent.com/6763261/130488362-dac2dec5-5071-4cf5-9ca1-58c2d03e23d6.png)
![image](https://user-images.githubusercontent.com/6763261/130488412-f8b81e46-5271-4706-a052-4d473390766f.png)



### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
