### PR TITLE
fix: preview video overflowing container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.45",
+  "version": "0.3.46",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "0.2.27",
+    "@100mslive/hms-video-store": "0.2.28",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/TwAvatar/Avatar.tsx
+++ b/src/components/TwAvatar/Avatar.tsx
@@ -129,7 +129,7 @@ export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
       }),
     [],
   );
-  const { width = 0, height = 0, ref } = useResizeDetector();
+  const { width = 0, ref } = useResizeDetector();
 
   const classList = [`${styler('root')}`];
   shape === 'circle'
@@ -137,7 +137,9 @@ export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
     : classList.push(`${styler('rootShapeSquare')}`);
   if (!image) {
     classList.push(`${styler('rootDivWrapper')}`);
-  } else {
+  }
+
+  if (shape !== 'circle') {
     if (size === 'sm') {
       classList.push(`${styler('rootSizeSm')}`);
     } else if (size === 'md') {

--- a/src/components/TwAvatar/Avatar.tsx
+++ b/src/components/TwAvatar/Avatar.tsx
@@ -139,7 +139,7 @@ export const Avatar: React.FC<PropsWithChildren<AvatarProps>> = ({
     classList.push(`${styler('rootDivWrapper')}`);
   }
 
-  if (shape !== 'circle') {
+  if (shape === 'square') {
     if (size === 'sm') {
       classList.push(`${styler('rootSizeSm')}`);
     } else if (size === 'md') {

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -112,7 +112,8 @@ export interface VideoTileClasses extends VideoClasses {
 }
 
 const defaultClasses: VideoTileClasses = {
-  root: 'group w-full h-full flex relative justify-center rounded-lg ',
+  root:
+    'group w-full h-full flex relative justify-center rounded-lg overflow-hidden',
   videoContainer: 'relative rounded-lg object-cover relative w-full max-h-full',
   avatarContainer:
     'absolute w-full h-full top-0 left-0 z-10 bg-gray-100 flex items-center justify-center rounded-lg',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@0.2.27":
-  version "0.2.27"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.27.tgz#cdca1c2ca71d3ed6abee5162141731ef94675131"
-  integrity sha512-cvayeHDqUIWA6oj3HRUeMJwZjaLH/a21VtPdqu3JdAM6eN0Ji+iUEnNobLlfC0g0LI4RWt1qnUNv85qsYQiskw==
+"@100mslive/hms-video-store@0.2.28":
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.28.tgz#bd8ec96324629671563cf0be8348a948b8a59f97"
+  integrity sha512-4spQOyYIbqL1j7HVJKw6Z2nL4pBaRatG51kemoU0yIbS6LkVb6U472FC1Ij0kjP7Svu3rJxpTSx1DS0NgZboQQ==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"


### PR DESCRIPTION
## Details

### Current Behaviour

- Preview video tile overflows when space available is less


### New Behaviour

- Hide the excess overflow.
- Fix avatar in participant list


### Screenshots



### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
