### PR TITLE
fix: audio level indicator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.46",
+  "version": "0.3.47",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "4.2.4"
   },
   "dependencies": {
-    "@100mslive/hms-video-store": "0.2.28",
+    "@100mslive/hms-video-store": "0.2.29",
     "@material-ui/core": "^4.11.3",
     "@twind/aspect-ratio": "^0.1.4",
     "autoprefixer": "^9.8.6",

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -112,8 +112,7 @@ export interface VideoTileClasses extends VideoClasses {
 }
 
 const defaultClasses: VideoTileClasses = {
-  root:
-    'group w-full h-full flex relative justify-center rounded-lg overflow-hidden',
+  root: 'group w-full h-full flex relative justify-center rounded-lg min-h-0',
   videoContainer: 'relative rounded-lg object-cover relative w-full max-h-full',
   avatarContainer:
     'absolute w-full h-full top-0 left-0 z-10 bg-gray-100 flex items-center justify-center rounded-lg',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@100mslive/hms-video-store@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.28.tgz#bd8ec96324629671563cf0be8348a948b8a59f97"
-  integrity sha512-4spQOyYIbqL1j7HVJKw6Z2nL4pBaRatG51kemoU0yIbS6LkVb6U472FC1Ij0kjP7Svu3rJxpTSx1DS0NgZboQQ==
+"@100mslive/hms-video-store@0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@100mslive/hms-video-store/-/hms-video-store-0.2.29.tgz#b198ca6580dd22b49e231036fd372687a9fed159"
+  integrity sha512-lMSukye53vcW7eTfo5gzjqXmogzkGPOYppeQDgTFwc2ggnotY6V1ynLrbaBjM4ataX2qRS86klY5FTkrJ1SAyg==
   dependencies:
     immer "^9.0.5"
     reselect "^4.0.0"


### PR DESCRIPTION
## Details

### Current Behaviour

- Audio level indicator not visible because of overflow.

### New Behaviour

- use min-height:0 instead of overflow to prevent element moving out of container


### Screenshots




### Choose one of these(put a 'x' in the bracket):
- [x] The change doesn't require a change to the documentation.
- [ ] The documentation is updated accordingly.


### Implementation note, gotchas and Future TODOs
