### PR TITLE
fix: Nested class parsing

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,7 +48,7 @@ interface StyledButtonProps {
   /**
    * className string
    */
-  classes?: { [key: string]: string } | ButtonClasses;
+  classes?: Partial<ButtonClasses>;
   /**
    * css styles declaration
    */
@@ -139,10 +139,7 @@ export const Button: React.FC<PropsWithChildren<ButtonProps>> = ({
     )}`,
   };
   const { tw } = useHMSTheme();
-  const finalClasses: ButtonClasses = resolveClasses(
-    classes || {},
-    defaultClasses,
-  );
+  const finalClasses = resolveClasses<ButtonClasses>(defaultClasses, classes);
   const button = style({
     base: `${finalClasses.root}`,
     variants: {

--- a/src/components/Preview/Preview.stories.tsx
+++ b/src/components/Preview/Preview.stories.tsx
@@ -38,6 +38,11 @@ Default.args = {
     authToken: 'token',
     userName: 'username',
   },
+  classes: {
+    joinButton: {
+      rootEmphasized: 'bg-yellow-500',
+    },
+  },
 };
 
 export const Light = LightTemplate.bind({});

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -33,7 +33,8 @@ export interface PreviewClasses {
   helloDiv?: string;
   nameDiv?: string;
   inputRoot?: string;
-  joinButton?: ButtonClasses;
+  joinButton?: Partial<ButtonClasses>;
+  videoTile?: Partial<VideoTileClasses>;
 }
 const defaultClasses: PreviewClasses = {
   root:
@@ -50,12 +51,11 @@ export interface PreviewProps {
   config: HMSConfig;
   joinOnClick: ({ audioMuted, videoMuted, name }: JoinInfo) => void;
   videoTileProps?: Partial<VideoTileProps>;
-  videoTileClasses?: VideoTileClasses;
   onNameChange?: (name: string) => void;
   /**
    * extra classes added  by user
    */
-  classes?: PreviewClasses;
+  classes?: Partial<PreviewClasses>;
 }
 
 export const Preview = ({
@@ -63,7 +63,6 @@ export const Preview = ({
   joinOnClick,
   videoTileProps,
   classes,
-  videoTileClasses,
   onNameChange,
 }: PreviewProps) => {
   const { tw } = useHMSTheme();
@@ -135,7 +134,7 @@ export const Preview = ({
                   width: 1,
                   height: 1,
                 }}
-                classes={videoTileClasses}
+                classes={classes?.videoTile}
                 controlsComponent={
                   <PreviewControls
                     audioButtonOnClick={() => setAudioEnabled(!audioEnabled)}
@@ -169,7 +168,7 @@ export const Preview = ({
           <Button
             variant="emphasized"
             size="lg"
-            classes={styler('joinButton') as ButtonClasses}
+            classes={classes?.joinButton}
             iconRight={inProgress || roomState === HMSRoomState.Connecting}
             icon={inProgress ? <ProgressIcon /> : undefined}
             disabled={inProgress || roomState === HMSRoomState.Connecting}

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -18,6 +18,7 @@ import { Input } from '../Input';
 import { hmsUiClassParserGenerator } from '../../utils/classes';
 import { useHMSActions, useHMSStore } from '../../hooks/HMSRoomProvider';
 import { isBrowser } from '../../utils/is-browser';
+import { ButtonClasses } from '../Button/Button';
 
 interface JoinInfo {
   audioMuted?: boolean;
@@ -32,7 +33,7 @@ export interface PreviewClasses {
   helloDiv?: string;
   nameDiv?: string;
   inputRoot?: string;
-  joinButton?: string;
+  joinButton?: ButtonClasses;
 }
 const defaultClasses: PreviewClasses = {
   root:
@@ -120,10 +121,10 @@ export const Preview = ({
   return (
     <Fragment>
       {/* root */}
-      <div className={styler('root')}>
-        <div className={styler('containerRoot')}>
+      <div className={styler('root') as string}>
+        <div className={styler('containerRoot') as string}>
           {/* header */}
-          <div className={styler('header')}>
+          <div className={styler('header') as string}>
             {/* videoTile */}
             {localPeer ? (
               <VideoTile
@@ -151,11 +152,11 @@ export const Preview = ({
             )}
           </div>
           {/* helloDiv */}
-          <div className={styler('helloDiv')}>Hi There</div>
+          <div className={styler('helloDiv') as string}>Hi There</div>
           {/* nameDiv */}
-          <div className={styler('nameDiv')}>What's your name?</div>
+          <div className={styler('nameDiv') as string}>What's your name?</div>
           {/* inputFieldRoot */}
-          <div className={styler('inputRoot')}>
+          <div className={styler('inputRoot') as string}>
             <Input
               ref={inputRef}
               {...inputProps}
@@ -168,6 +169,7 @@ export const Preview = ({
           <Button
             variant="emphasized"
             size="lg"
+            classes={styler('joinButton') as ButtonClasses}
             iconRight={inProgress || roomState === HMSRoomState.Connecting}
             icon={inProgress ? <ProgressIcon /> : undefined}
             disabled={inProgress || roomState === HMSRoomState.Connecting}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -35,7 +35,7 @@ interface StyledTextProps {
   /**
    * className string
    */
-  classes?: { [key: string]: string } | TextClasses;
+  classes?: Partial<TextClasses>;
   /**
    * css styles declaration
    */
@@ -80,10 +80,7 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
   styles,
   ...props
 }) => {
-  const finalClasses: TextClasses = resolveClasses(
-    classes || {},
-    defaultClasses,
-  );
+  const finalClasses: TextClasses = resolveClasses(defaultClasses, classes);
   const { tw } = useHMSTheme();
   const TagName = tag || 'span';
   const typography = style({

--- a/src/utils/classes/index.tsx
+++ b/src/utils/classes/index.tsx
@@ -1,15 +1,24 @@
 // @ts-ignore
 import { apply, TW } from 'twind';
 
-export const resolveClasses = (obj1: any, obj2: any) => {
-  const hash: any = {};
-  Object.keys(obj2).forEach(k => {
-    if (obj1.hasOwnProperty(k)) {
-      hash[k] = `${(obj2 as any)[k]} ${(obj1 as any)[k]}`;
+export const resolveClasses = <T extends Record<string, any>>(
+  defaults: T,
+  custom?: T,
+): T => {
+  if (!custom) {
+    return defaults;
+  }
+
+  const hash = { ...defaults };
+
+  for (const k in defaults) {
+    if (custom.hasOwnProperty(k)) {
+      Object.assign(hash, { k: `${defaults[k]} ${custom[k]}` });
     } else {
-      hash[k] = (obj2 as any)[k];
+      hash[k] = defaults[k];
     }
-  });
+  }
+
   return hash;
 };
 
@@ -49,7 +58,7 @@ export const hmsUiClassParserGenerator = <T extends {}>({
   defaultClasses,
   tag,
 }: ParseClassProps<T>) => (s: keyof T) => {
-  const finalClasses = resolveClasses(classes || {}, defaultClasses);
+  const finalClasses = resolveClasses<T>(defaultClasses, classes);
   if (tw) {
     return tw(
       `${tag}-${s}`,
@@ -57,7 +66,7 @@ export const hmsUiClassParserGenerator = <T extends {}>({
       apply(finalClasses[s]),
     );
   }
-  //handle edge case of tw not being present
+  // handle edge case of tw not being present
   else {
     return defaultStyler(defaultClasses, s);
   }

--- a/src/utils/classes/index.tsx
+++ b/src/utils/classes/index.tsx
@@ -3,7 +3,7 @@ import { apply, TW } from 'twind';
 
 export const resolveClasses = <T extends Record<string, any>>(
   defaults: T,
-  custom?: T,
+  custom?: Partial<T>,
 ): T => {
   if (!custom) {
     return defaults;
@@ -13,9 +13,7 @@ export const resolveClasses = <T extends Record<string, any>>(
 
   for (const k in defaults) {
     if (custom.hasOwnProperty(k)) {
-      Object.assign(hash, { k: `${defaults[k]} ${custom[k]}` });
-    } else {
-      hash[k] = defaults[k];
+      Object.assign(hash, { [k]: `${defaults[k]} ${custom[k]}` });
     }
   }
 
@@ -63,6 +61,7 @@ export const hmsUiClassParserGenerator = <T extends {}>({
     return tw(
       `${tag}-${s}`,
       (customClasses && (customClasses[s] as unknown)) as string,
+      // @ts-ignore
       apply(finalClasses[s]),
     );
   }


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

* Allow nested parsing of classes. For example, set class of root in joinButton inside Preview. Example:
```jsx
<Preview
  classes={{
    joinButton: {
      rootEmphasized: 'bg-yellow-500',
    },
  }}
/>
```

### Screenshots

### Implementation note, gotchas, related work and Future TODOs (optional)
- Make nested classes for VideoList, VideoTile, Video.