### PR TITLE
feat: export HMSDialog and convert props to be optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.73",
+  "version": "0.3.74",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/ControlBar/ControlBar.tsx
+++ b/src/components/ControlBar/ControlBar.tsx
@@ -25,13 +25,13 @@ export interface ControlBarProps {
   isAudioMuted?: boolean;
   isVideoMuted?: boolean;
   isChatOpen?: boolean;
-  buttonDisplay: ButtonDisplayType;
+  buttonDisplay?: ButtonDisplayType;
 
   audioButtonOnClick: React.MouseEventHandler;
   videoButtonOnClick: React.MouseEventHandler;
-  leaveButtonOnClick: React.MouseEventHandler;
-  chatButtonOnClick: React.MouseEventHandler;
-  screenshareButtonOnClick: React.MouseEventHandler;
+  leaveButtonOnClick?: React.MouseEventHandler;
+  chatButtonOnClick?: React.MouseEventHandler;
+  screenshareButtonOnClick?: React.MouseEventHandler;
 
   leftComponents: Array<React.ReactNode>;
   centerComponents: Array<React.ReactNode>;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Dialog, withStyles } from '@material-ui/core';
+
+
+export const HMSDialog = withStyles({
+  paper: {
+    borderRadius: '12px',
+    backgroundColor: 'inherit',
+  },
+})(Dialog);

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,0 +1,1 @@
+export { HMSDialog } from './Dialog';

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -11,8 +11,8 @@ export interface HeaderClasses {
   rightRoot?: string;
 }
 export interface HeaderProps {
-  time: number;
-  speaker: string;
+  time?: number;
+  speaker?: string;
   leftComponents: Array<React.ReactNode>;
   centerComponents: Array<React.ReactNode>;
   rightComponents: Array<React.ReactNode>;

--- a/src/components/ParticipantList/ParticipantList.tsx
+++ b/src/components/ParticipantList/ParticipantList.tsx
@@ -23,10 +23,10 @@ import {
   ParticipantListClasses,
   ParticipantListProps,
 } from './ParticipantProps';
-import { Dialog, withStyles } from '@material-ui/core';
 import { Text } from '../Text';
 import { selectAvailableRoleNames } from '@100mslive/hms-video-store';
 import { Button } from '../Button';
+import { HMSDialog } from '../Dialog';
 
 const defaultClasses: ParticipantListClasses = {
   root: 'flex flex-grow border-opacity-0 sm:hidden md:inline-block relative',
@@ -68,13 +68,6 @@ const customClasses: ParticipantListClasses = {
   menuRoot: 'hmsui-participantList-scrollbar',
   onIcon: 'hmsui-participantList-show-on-group-hover',
 };
-
-const HMSDialog = withStyles({
-  paper: {
-    borderRadius: '12px',
-    backgroundColor: 'inherit',
-  },
-})(Dialog);
 
 export const ParticipantList = ({
   participantList,

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,6 +1,4 @@
 import React, { ChangeEventHandler, useMemo, useState, useEffect } from 'react';
-import Dialog from '@material-ui/core/Dialog';
-import { withStyles } from '@material-ui/core/styles';
 import {
   selectLocalMediaSettings,
   selectDevices,
@@ -15,6 +13,7 @@ import { SettingsIcon, CloseIcon } from '../Icons';
 import { useHMSActions, useHMSStore } from '../../hooks/HMSRoomProvider';
 import { useHMSTheme } from '../../hooks/HMSThemeProvider';
 import { hmsUiClassParserGenerator } from '../../utils/classes';
+import { HMSDialog } from '../Dialog';
 
 interface SettingsClasses {
   root?: string;
@@ -72,12 +71,6 @@ const customClasses: SettingsClasses = {
   dialogContainer: 'no-scrollbar ',
 };
 
-const HMSDialog = withStyles({
-  paper: {
-    borderRadius: '12px',
-    backgroundColor: 'inherit',
-  },
-})(Dialog);
 //TODO split button and settings dialog
 
 export const Settings = ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from './components/Text';
 export * from './components/ContextMenu';
 export * from './components/ParticipantsInView';
 export * from './components/Playlist';
+export * from './components/Dialog';
 export {
   HMSRoomProvider,
   useHMSStore,


### PR DESCRIPTION
:lipstick: :recycle: Exporting the default HMSDialog and converting props to be optional in various places.

### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

* It will expose your HMSDialog component which so that i don't have to use `@material/core` in my repo.
* It will make some components TS compatible as it makes some props optional which have default implementation.

### Screenshots

### Implementation note, gotchas, related work and Future TODOs (optional)
