### PR TITLE
feat: allow for passing custom inner element to videotile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.88",
+  "version": "0.3.89",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/components/VideoList/VideoList.stories.tsx
+++ b/src/components/VideoList/VideoList.stories.tsx
@@ -29,6 +29,18 @@ interface VideoListStoryProps extends VideoListProps {
   height?: string;
 }
 
+function VideoTileInnerComponent({
+  peer,
+  track,
+}: {
+  peer: HMSPeer;
+  track?: HMSTrack;
+}) {
+  return (
+    <span className="absolute bottom-4 bg-red-600 left-4">{`peer${peer?.id},track${track?.id}`}</span>
+  );
+}
+
 const Template: Story<VideoListStoryProps> = args => {
   const dummyCameraVideoRef = useRef<HTMLVideoElement>(null);
   const dummyScreenVideoRef = useRef<HTMLVideoElement>(null);
@@ -74,7 +86,13 @@ const Template: Story<VideoListStoryProps> = args => {
           loop
           autoPlay
         ></video>
-        <VideoList {...args} peers={storyBookSDK.getPeers()} />
+        <VideoList
+          {...args}
+          peers={storyBookSDK.getPeers()}
+          videoTileProps={(peer, track) => {
+            return { innerComponent: VideoTileInnerComponent({ peer, track }) };
+          }}
+        />
       </div>
     </HMSThemeProvider>
   );
@@ -197,6 +215,11 @@ const MeetTemplate: Story<VideoListStoryProps> = (
                   showAudioMuteStatus={true}
                 />
               ))}
+              videoTileProps={(peer, track) => {
+                return {
+                  innerComponent: VideoTileInnerComponent({ peer, track }),
+                };
+              }}
             />
           }
         </div>

--- a/src/components/VideoTile/VideoTile.stories.tsx
+++ b/src/components/VideoTile/VideoTile.stories.tsx
@@ -32,6 +32,12 @@ const meta: Meta = {
 
 export default meta;
 
+function VideoTileInnerComponent() {
+  return (
+    <span className="absolute bottom-4 bg-red-600 left-4">HandRaiseIcon</span>
+  );
+}
+
 const Template: Story<VideoTileProps> = (args: VideoTileProps) => {
   const [videoTrack, setVideoTrack] = useState<MediaStreamTrack>();
   const [audioTrack, setAudioTrack] = useState<MediaStreamTrack>();
@@ -85,11 +91,8 @@ const Template: Story<VideoTileProps> = (args: VideoTileProps) => {
           peer={(() => storyBookSDK.getRandomPeer())()}
           videoTrack={videoTrack}
           audioTrack={audioTrack}
-        >
-          <span className="absolute bottom-4 bg-red-600 left-4">
-            HandRaiseIcon
-          </span>
-        </VideoTile>
+          innerComponent={VideoTileInnerComponent()}
+        />
       </div>
     </HMSThemeProvider>
   );

--- a/src/components/VideoTile/VideoTile.tsx
+++ b/src/components/VideoTile/VideoTile.tsx
@@ -36,7 +36,7 @@ import { hmsUiClassParserGenerator } from '../../utils/classes';
 import './index.css';
 
 export interface AdditionalVideoTileProps {
-  children?: React.ReactNode;
+  innerComponent?: React.ReactNode;
   customAvatar?: React.ReactNode;
 
   /**
@@ -158,7 +158,7 @@ export const VideoTile = ({
   compact = false,
   customAvatar,
   contextMenuItems,
-  children,
+  innerComponent,
 }: VideoTileProps) => {
   const { appBuilder, tw, tailwindConfig, toast } = useHMSTheme();
   const hmsActions = useHMSActions();
@@ -471,7 +471,7 @@ export const VideoTile = ({
             )}
           </div>
         )}
-        {children}
+        {innerComponent}
       </div>
     </ClickAwayListener>
   );


### PR DESCRIPTION
### Details(context, Jira ticket, how was the bug fixed, what does the new feature do)

* Videotile can now take innercomponent to display things like for eg. hand raise icon
* It can also be passed from VideoList as videotileprops
* https://hms-video-react-5yyz3wfj1-100mslive.vercel.app/?path=/story/video-list--default-list

### Screenshots

<img width="1521" alt="Screenshot 2021-10-09 at 2 39 27 PM" src="https://user-images.githubusercontent.com/16299282/136652072-32745a15-f0c3-43f7-a2a8-261921c10681.png">

The red horizontal bar with peer, track on bottom left side in above image

### Implementation note, gotchas, related work and Future TODOs (optional)
